### PR TITLE
Add minimal CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+---
+version: 2.1
+
+jobs:
+  build:
+    docker:
+    - image: cimg/base:stable-20.04
+    executor: base
+
+    steps:
+    - checkout
+    - run: sudo apt-get update
+    - run: sudo apt-get install -y libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev libmysqlclient-dev
+    - run: cmake .
+    - run: make
+
+workflows:
+  version: 2
+  mydumper:
+    jobs:
+    - build:
+        filters:
+          tags:
+            only: /.*/


### PR DESCRIPTION
Add a simple build pipeline using CircleCI. This is just a first step.

This can be extended to test multiple combinations of different base
iamges, MySQL client libraries, and then integration tests with data.

Signed-off-by: SuperQ <superq@gmail.com>