### PR TITLE
Master and Server data stored in same medatdata file, difficult to distinguish

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -505,7 +505,7 @@ void write_snapshot_info(MYSQL *conn, FILE *file) {
       fprintf(file, "SHOW SLAVE STATUS:");
       if (isms)
         fprintf(file, "\n\tConnection name: %s", connname);
-      fprintf(file, "\n\tHost: %s\n\tLog: %s\n\tPos: %s\n\tGTID:%s\n\n",
+      fprintf(file, "\n\tHost: %s\n\tMaster_Log_File: %s\n\tRead_Master_Log_Pos: %s\n\tGTID:%s\n\n",
               slavehost, slavelog, slavepos, slavegtid);
       g_message("Written slave status");
     }


### PR DESCRIPTION
The format of the master and slave status in the "metadata" file is very similar. This can cause confusion. https://github.com/maxbube/mydumper/issues/55