### PR TITLE
Adding pause when there is no enough free disk space

### DIFF
--- a/mydumper.h
+++ b/mydumper.h
@@ -46,6 +46,7 @@ struct configuration {
   GAsyncQueue *ready_less_locking;
   GAsyncQueue *ready_database_dump;
   GAsyncQueue *unlock_tables;
+  GAsyncQueue *pause_resume;
   GMutex *mutex;
   int done;
 };


### PR DESCRIPTION
We are adding a monitoring thread that is going check the remaining free disk space every 10 seconds. When the free space is lower than the configured value, it will pause the threads that are trying to pop a new job from the queue until the free space is higher than the configured value. 
Threads that are running will continue, we are not pausing job executions, we are pausing pop from the queue. 
