### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM gcc:11-bullseye
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y lsb-release \
-  && \
+  apt-get install -y lsb-release && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/
 
@@ -18,9 +18,8 @@ RUN \
 
 RUN \
   apt-get update && \
-  DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y \
-      libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev cmake g++ libperconaserverclient20-dev libperconaserverclient20 \
+  apt-get install -y \
+    libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev cmake g++ libperconaserverclient20-dev libperconaserverclient20 \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
+# Using Debian's GCC image, pinned to latest LTS, scheduled to EOL on Jun'26.
 FROM gcc:11-bullseye
+
+# Docker build arguments. Use to customize build.
+# Example to enable ZSTD:
+# $ docker build ---build-arg CMAKE_ARGS='-DWITH_ZSTD=ON' mydumper .
+ARG PERCONA_COMPONENT
+ARG CMAKE_ARGS
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Package 'lsb-release' is required by 'percona-release' package.
 RUN \
   apt-get update && \
   apt-get install -y lsb-release && \
@@ -16,10 +24,18 @@ RUN \
   dpkg -i /tmp/percona-release.deb && \
   rm -v /tmp/percona-release.deb
 
+# Temp fix required due to 'percona-release' failing to detect package repos.
 RUN \
+  sed -i 's/curl -Is/curl -ILs/g' /usr/bin/percona-release && \
+  sed -i 's/http:/https:/g' /usr/bin/percona-release && \
+  grep http /usr/bin/percona-release
+
+RUN \
+  percona-release enable-only ps-80 ${PERCONA_COMPONENT:-release} && \
   apt-get update && \
   apt-get install -y \
-    libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev cmake g++ libperconaserverclient20-dev libperconaserverclient20 \
+    libglib2.0-dev zlib1g-dev libpcre3-dev libssl-dev cmake g++ \
+    libperconaserverclient21-dev libperconaserverclient21 libzstd-dev \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/
@@ -28,6 +44,6 @@ COPY . /usr/src/
 WORKDIR /usr/src/
 
 RUN \
-  cmake . && \
+  cmake ${CMAKE_ARGS} . && \
   make && \
   make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-FROM gcc
-FROM ubuntu:latest
+FROM gcc:11-bullseye
 
 RUN \
   apt-get update && \
   DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y lsb-release curl gnupg2 \
+    apt-get install -y lsb-release \
   && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/
 
 RUN \
+  . /etc/os-release && \
   curl --fail --location --show-error --silent --output /tmp/percona-release.deb \
-    https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb \
+    https://repo.percona.com/apt/percona-release_latest.${VERSION_CODENAME}_all.deb \
   && \
   dpkg -i /tmp/percona-release.deb && \
   rm -v /tmp/percona-release.deb


### PR DESCRIPTION
Build is failing due to `percona-release` failing to detect the `ps-80` repo. I've found the culprit in the script calls to `curl`. Try removing the commented temporary fixes to check it.

I've made some other improvements, as described in the commit messages. For instance, now you can build with ZSTD support.

You can test the build straight from my repo:
```bash
docker build --build-arg CMAKE_ARGS='-DWITH_ZSTD=ON' -t mydumper github.com/pataquets/mydumper#dockerfile-fixes
```

I preferred not enabling ZSTD by default to preserve non-Docker defaults and not installing Sphinx, since it's not strictly required. Feedback welcome.

Also, I think the `docker` command line above could be worth adding somewhere in the docs.