### PR TITLE
Dockerfile: Print message if missing CMD at run. Add verbosity.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN \
     https://repo.percona.com/apt/percona-release_latest.${VERSION_CODENAME}_all.deb \
   && \
   dpkg -i /tmp/percona-release.deb && \
-  rm -v /tmp/percona-release.deb
+  rm -v /tmp/percona-release.deb && \
+  percona-release show
 
 # Temp fix required due to 'percona-release' failing to detect package repos.
 RUN \
@@ -47,3 +48,6 @@ RUN \
   cmake ${CMAKE_ARGS} . && \
   make && \
   make install
+
+# Compilation outputs both mydumper and myloader binaries.
+CMD [ "bash", "-c", "echo 'This Docker image contains both mydumper and myloader binaries. Run the container by invoking either mydumper or myloader as first argument.'" ]


### PR DESCRIPTION
Since running the image without arguments drops you straight into the `bash` prompt:
```console
$ docker run --rm -it mydumper
root@2cc401074ecf:/usr/src#
```

I've thought it would be more useful to print some help text if no CMD provided:
```console
$ docker run --rm -it mydumper
This Docker image contains both mydumper and myloader binaries. Run the container by invoking either mydumper or myloader as first argument.
```
Notice that if you really want a shell when launching the container you can also pass `bash` as the first argument.

Also, the build process now prints the output of the `percona-release show` command right after installing it, to provide more verbosity:
```
The following repositories are enabled on your system:
original - release
prel - release
<*> All done!
```
(Reproduced here to help reviewing if this output is the intended)