### PR TITLE
Ignoring User/host/password from variables and anonimized function are being loaded from default file

### DIFF
--- a/myloader.c
+++ b/myloader.c
@@ -353,7 +353,7 @@ int main(int argc, char *argv[]) {
   detected_server = detect_server(conn);
   GHashTable * set_session_hash = initialize_hash_of_session_variables();
   if (defaults_file)
-    load_hash_from_key_file(set_session_hash, defaults_file, "myloader_variables");
+    load_hash_from_key_file(set_session_hash, NULL, defaults_file, "myloader_variables");
   refresh_set_session_from_hash(set_session,set_session_hash);
   execute_gstring(conn, set_session);
 

--- a/src/common.h
+++ b/src/common.h
@@ -30,7 +30,8 @@ void load_config_file(gchar * config_file, GOptionContext *context, const gchar 
 void execute_gstring(MYSQL *conn, GString *ss);
 gchar * identity_function(gchar ** r);
 gchar *replace_escaped_strings(gchar *c);
-void load_hash_from_key_file(GHashTable * set_session_hash, gchar * config_file, const gchar * group_variables);
+void load_hash_from_key_file(GHashTable * set_session_hash, GHashTable *all_anonymized_function, gchar * config_file, const gchar * group_variables);
+//void load_hash_from_key_file(GHashTable * set_session_hash, gchar * config_file, const gchar * group_variables);
 void refresh_set_session_from_hash(GString *ss, GHashTable * set_session_hash);
 gboolean is_table_in_list(gchar *table_name, gchar **table_list);
 #endif


### PR DESCRIPTION
There were variables that were been loaded on the variables from the default file, but there was no need as the client was taking the same information from the default file. Now, we are ignoring those variables.

We also add the functionality needed to load the function reference from the configuration file. This is an example:
```
[`issue_574`.`test_json`]
id = random_int
```
where
```
[`<schema_name>`.`<table_name>`]
<column1_name> = <function_name>
<column2_name> = <function_name>
```
There is a last phase to complete the anonymized dump feature:
- Add more functions!
which may be a task that will never ends as it will depend on what people want.