### PR TITLE
set verbosity level earlier

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1227,14 +1227,12 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  set_verbose(verbose?verbose:2);
+  set_verbose(verbose);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "mydumper");
   }
   g_option_context_free(context);
-
-  set_verbose(verbose);
 
   if (!compress_output) {
     m_open=&g_fopen;

--- a/mydumper.c
+++ b/mydumper.c
@@ -1227,12 +1227,14 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  set_verbose(verbose);
+  set_verbose(2);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "mydumper");
   }
   g_option_context_free(context);
+
+  set_verbose(verbose);
 
   if (!compress_output) {
     m_open=&g_fopen;

--- a/mydumper.c
+++ b/mydumper.c
@@ -1227,6 +1227,8 @@ int main(int argc, char *argv[]) {
     }
   }
 
+  set_verbose(verbose);
+
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "mydumper");
   }
@@ -1334,7 +1336,6 @@ int main(int argc, char *argv[]) {
     exit(EXIT_SUCCESS);
   }
 
-  set_verbose(verbose);
 
   GDateTime * datetime = g_date_time_new_now_local();
 

--- a/mydumper.c
+++ b/mydumper.c
@@ -1227,7 +1227,7 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  set_verbose(2);
+  set_verbose(verbose?verbose:2);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "mydumper");

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -193,12 +193,14 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  set_verbose(verbose);
+  set_verbose(2);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "myloader");
   }
   g_option_context_free(context);
+
+  set_verbose(verbose);
 
   hide_password(argc, argv);
   ask_password();

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  set_verbose(2);
+  set_verbose(verbose?verbose:2);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "myloader");

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -193,14 +193,12 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
-  set_verbose(verbose?verbose:2);
+  set_verbose(verbose);
 
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "myloader");
   }
   g_option_context_free(context);
-
-  set_verbose(verbose);
 
   hide_password(argc, argv);
   ask_password();

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -193,6 +193,8 @@ int main(int argc, char *argv[]) {
     exit(EXIT_FAILURE);
   }
 
+  set_verbose(verbose);
+
   if (defaults_file != NULL){
     load_config_file(defaults_file, context, "myloader");
   }
@@ -207,7 +209,6 @@ int main(int argc, char *argv[]) {
     exit(EXIT_SUCCESS);
   }
 
-  set_verbose(verbose);
 #ifdef ZWRAP_USE_ZSTD
   compress_extension = g_strdup(".zst");
 #else


### PR DESCRIPTION
The verbosity flag is initialized after attempts to read the
defaults-file argument so warnings are printed for missing
[mydumper] headers in the client file even when verbosity is
set to 1.