### PR TITLE
restore defaults-file override behavior

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1336,6 +1336,7 @@ int main(int argc, char *argv[]) {
     exit(EXIT_SUCCESS);
   }
 
+  set_verbose(verbose);
 
   GDateTime * datetime = g_date_time_new_now_local();
 

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -209,6 +209,8 @@ int main(int argc, char *argv[]) {
     exit(EXIT_SUCCESS);
   }
 
+  set_verbose(verbose);
+
 #ifdef ZWRAP_USE_ZSTD
   compress_extension = g_strdup(".zst");
 #else

--- a/src/set_verbose.c
+++ b/src/set_verbose.c
@@ -33,6 +33,23 @@
 
 #include "logging.h"
 
+/* two handlers currently defined: no_log, write_log_file */
+#define total_handlers 2
+#define use_no_log 0
+#define use_write_log_file 1
+
+static guint log_handlers[total_handlers] = {};
+
+static void free_log_handlers() {
+  for (int x = 0; x < total_handlers; x++) {
+    if (log_handlers[x] != 0) {
+      g_log_remove_handler(NULL, log_handlers[x]);
+      log_handlers[x] = 0;
+    }
+  }
+}
+
+
 void set_verbose(guint verbosity) {
   if (logfile) {
     logoutfile = g_fopen(logfile, "w");
@@ -43,24 +60,29 @@ void set_verbose(guint verbosity) {
     }
   }
 
+  free_log_handlers();
+
   switch (verbosity) {
   case 0:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK), no_log, NULL);
+    log_handlers[use_no_log] = g_log_set_handler(
+        NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK),
+        no_log, NULL);
     break;
   case 1:
-    g_log_set_handler(
+    log_handlers[use_no_log] = g_log_set_handler(
         NULL, (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_MESSAGE),
         no_log, NULL);
     if (logfile)
-      g_log_set_handler(
+      log_handlers[use_write_log_file] = g_log_set_handler(
           NULL, (GLogLevelFlags)(G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL),
           write_log_file, NULL);
     break;
   case 2:
-    g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MESSAGE), no_log,
-                      NULL);
+    log_handlers[use_no_log] = g_log_set_handler(
+        NULL, (GLogLevelFlags)(G_LOG_LEVEL_MESSAGE),
+        no_log, NULL);
     if (logfile)
-      g_log_set_handler(
+      log_handlers[use_write_log_file] = g_log_set_handler(
           NULL,
           (GLogLevelFlags)(G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
                            G_LOG_LEVEL_WARNING | G_LOG_LEVEL_ERROR |
@@ -69,8 +91,9 @@ void set_verbose(guint verbosity) {
     break;
   default:
     if (logfile)
-      g_log_set_handler(NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK),
-                        write_log_file, NULL);
+      log_handlers[use_write_log_file] = g_log_set_handler(
+          NULL, (GLogLevelFlags)(G_LOG_LEVEL_MASK),
+          write_log_file, NULL);
     break;
   }
 }


### PR DESCRIPTION
Previously I made a commit (3d2905a89c68e17069bda289f0cfe3d8e3893846)
 to stop warning output appearing when
the verbosity was set to 1.  This ended up causing the verbose flag
to get ignored in the defaults-file and only usable when
passed via the cli.  The previous behavior was
to always use the value in a passed in defaults-file and override
anything passed in on the cli. This restores the old behavior
while ensuring warning messages are not logged when the verbosity
is reduced to 1. The commit adds a static function in set_verbose.c
that is used whenever set_verbose is called, it looks for previous
log_handlers that get returned from calls to g_log_set_handler and
closes them and then re-initializes the logger.