### PR TITLE
Dockerfile: use multi-stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.bzrignore
+.dockerignore
+.gitignore
+.github
+.circleci
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using Debian's GCC image, pinned to latest LTS, scheduled to EOL on Jun'26.
-FROM gcc:11-bullseye
+FROM gcc:11-bullseye as builder
 
 # Docker build arguments. Use to customize build.
 # Example to enable ZSTD:
@@ -48,6 +48,38 @@ RUN \
   cmake ${CMAKE_ARGS} . && \
   make && \
   make install
+
+
+FROM debian:bullseye
+ARG DEBIAN_FRONTEND=noninteractive
+RUN \
+  apt-get update && \
+  apt-get install -y curl lsb-release gnupg && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+RUN \
+  . /etc/os-release && \
+  curl --fail --location --show-error --silent --output /tmp/percona-release.deb \
+    https://repo.percona.com/apt/percona-release_latest.${VERSION_CODENAME}_all.deb \
+  && \
+  dpkg -i /tmp/percona-release.deb && \
+  rm -v /tmp/percona-release.deb && \
+  percona-release show
+
+# Temp fix required due to 'percona-release' failing to detect package repos.
+RUN \
+  sed -i 's/curl -Is/curl -ILs/g' /usr/bin/percona-release && \
+  sed -i 's/http:/https:/g' /usr/bin/percona-release
+
+RUN \
+  percona-release enable-only ps-80 ${PERCONA_COMPONENT:-release} && \
+  apt-get update && \
+  apt-get install -y libperconaserverclient21 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Compilation outputs both mydumper and myloader binaries.
 CMD [ "bash", "-c", "echo 'This Docker image contains both mydumper and myloader binaries. Run the container by invoking either mydumper or myloader as first argument.'" ]


### PR DESCRIPTION
Hi,
Using multi-stage builds allows us to separate build and run stages.
In this case, separating the build step into another images decreases the
final image size from 1300Mb to 290Mb.

Signed-off-by: Frank Villaro-Dixon <frank.villaro@infomaniak.com>