### PR TITLE
Use 0.11.5-2 in installation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ First get the correct url from the [releases section](https://github.com/maxbube
 ### RedHat / Centos
 
 ```bash
-yum install https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper-0.11.5-1.el7.x86_64.rpm
-yum install https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper-0.11.5-1.el8.x86_64.rpm
+yum install https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper-0.11.5-2.el7.x86_64.rpm
+yum install https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper-0.11.5-2.el8.x86_64.rpm
 ```
 
 ### Ubuntu / Debian
@@ -32,8 +32,8 @@ apt-get install libatomic1
 ```
 Then you can download and install the package:
 ```bash
-wget https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper_0.11.5-1.$(lsb_release -cs)_amd64.deb
-dpkg -i mydumper_0.11.5-1.$(lsb_release -cs)_amd64.deb
+wget https://github.com/mydumper/mydumper/releases/download/v0.11.5/mydumper_0.11.5-2.$(lsb_release -cs)_amd64.deb
+dpkg -i mydumper_0.11.5-2.$(lsb_release -cs)_amd64.deb
 ```
 
 ### FreeBSD


### PR DESCRIPTION
The readme currently recommends 0.11.5-1 but this version has a bug that causes indexes to not restore properly, so I have updated it to the fixed version. I'm not sure if 0.12.1 would be better to use here instead?