### PR TITLE
Dockerfile: add missing libglib2.0 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ FROM debian:bullseye
 ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   apt-get update && \
-  apt-get install -y curl lsb-release gnupg && \
+  apt-get install -y curl lsb-release gnupg libglib2.0 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
Hi,

This commit adds a missing runtime package. Sorry for the fuckup :(

Thanks and cheers !
Frank