### PR TITLE
print sigint confirmation to stdout instead of to a log file

### DIFF
--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -372,7 +372,7 @@ gboolean sig_triggered(void * user_data, int signal) {
       ((struct configuration *)user_data)->pause_resume = g_async_queue_new();
     GAsyncQueue *queue = ((struct configuration *)user_data)->pause_resume;
     if (!daemon_mode){
-      g_critical("Ctrl+c detected! Are you sure you want to cancel(Y/N)?");
+      fprintf(stdout, "Ctrl+c detected! Are you sure you want to cancel(Y/N)?");
       for(i=0;i<num_threads;i++){
         g_mutex_lock(pause_mutex_per_thread[i]);
         g_async_queue_push(queue,pause_mutex_per_thread[i]);

--- a/src/myloader_restore_job.c
+++ b/src/myloader_restore_job.c
@@ -231,7 +231,7 @@ gboolean sig_triggered(void * user_data, int signal) {
       g_mutex_lock(pause_mutex_per_thread[i]);
       g_async_queue_push(queue,pause_mutex_per_thread[i]);
     }
-    g_critical("Ctrl+c detected! Are you sure you want to cancel(Y/N)?");
+    fprintf(stdout, "Ctrl+c detected! Are you sure you want to cancel(Y/N)?");
     int c=0;
     while (1){
       do{


### PR DESCRIPTION
Maybe a overly simple solution but I had the same issue as #610 as well.  Calling fprintf to stdout got the desired behavior.