### PR TITLE
Adding critical message when DDL fails

### DIFF
--- a/src/myloader_restore.c
+++ b/src/myloader_restore.c
@@ -50,7 +50,7 @@ int restore_data_in_gstring_by_statement(struct thread_data *td, GString *data, 
 {
   if (mysql_real_query(td->thrconn, data->str, data->len)) {
     if (is_schema)
-      g_critical("Error restoring: %s %s", data->str, mysql_error(conn));
+      g_critical("Error restoring: %s %s", data->str, mysql_error(td->thrconn));
     errors++;
     return 1;
   }

--- a/src/myloader_restore.c
+++ b/src/myloader_restore.c
@@ -49,7 +49,8 @@ void load_restore_entries(GOptionGroup *main_group){
 int restore_data_in_gstring_by_statement(struct thread_data *td, GString *data, gboolean is_schema, guint *query_counter)
 {
   if (mysql_real_query(td->thrconn, data->str, data->len)) {
-    //g_critical("Error restoring: %s %s", data->str, mysql_error(conn));
+    if (is_schema)
+      g_critical("Error restoring: %s %s", data->str, mysql_error(conn));
     errors++;
     return 1;
   }


### PR DESCRIPTION
We are also dumping the DDL that is failing, so users can add it manually if they have to.