### PR TITLE
Allow compilation on Clang

### DIFF
--- a/src/myloader_stream.c
+++ b/src/myloader_stream.c
@@ -210,7 +210,7 @@ void *process_stream_queue(struct thread_data * td) {
   enum file_type ft=0;
 //  enum file_type ft;
   while (cont){
-    ft=(enum file_type)g_async_queue_pop(stream_queue);
+    ft=(enum file_type)GPOINTER_TO_INT(g_async_queue_pop(stream_queue));
     job=g_async_queue_try_pop(stream_conf->database_queue);
     if (job != NULL){
       g_debug("Restoring database");


### PR DESCRIPTION
Clang seems to be more strict in terms of casting. The `file_type` enum, which is pushed via `GINT_TO_POINTER` macro, needs to be casted on the other way around when popping (`GPOINTER_TO_INT`), otherwise the following error is raised on compilation:

    src/myloader_stream.c:213:8: error: cast to smaller integer type 'enum file_type' from 'gpointer' (aka 'void *') [-Werror,-Wvoid-pointer-to-enum-cast]
        ft=(enum file_type)g_async_queue_pop(stream_queue);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Tested on Clang 13.0.1 on Linux, via multithreaded streaming dump+restore.

See https://developer.gimp.org/api/2.0/glib/glib-Type-Conversion-Macros.html for the Glib macros reference.