### PR TITLE
Update README.md fixing html docs build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ dpkg -i mydumper_0.9.5-1.xenial_amd64.deb
 Run:
 
 ```bash
-cmake .
+cd mydumper && mkdir bld && cd bld
+cmake ..
 make
 ```
 


### PR DESCRIPTION
fix following exception on building HTML documentation with Sphinx, by build in another directory:

Exception occurred:
  File "/usr/lib64/python2.7/shutil.py", line 69, in copyfile
    raise Error("`%s` and `%s` are the same file" % (src, dst))
Error: `/data/compile/mydumper/docs/html/_static/down-pressed.png` and `/data/compile/mydumper/docs/html/_static/down-pressed.png` are the same file