### PR TITLE
Add missing includes

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -16,6 +16,7 @@
 #include <glib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
 #include <glib/gstdio.h>

--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -19,6 +19,7 @@
                     David Ducos, Percona (david dot ducos at percona dot com)
 */
 #include "string.h"
+#include <stdlib.h>
 #include <mysql.h>
 #include <glib.h>
 #include <glib/gstdio.h>

--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -21,6 +21,7 @@
 #include <mysql.h>
 #include <glib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #include <glib/gstdio.h>

--- a/src/myloader_common.c
+++ b/src/myloader_common.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifdef ZWRAP_USE_ZSTD
 #include "../zstd/zstd_zlibwrapper.h"

--- a/src/myloader_control_job.c
+++ b/src/myloader_control_job.c
@@ -15,6 +15,7 @@
         Authors:    David Ducos, Percona (david dot ducos at percona dot com)
 */
 #include <glib.h>
+#include <stdlib.h>
 #include "myloader_control_job.h"
 #include "myloader_restore_job.h"
 

--- a/src/myloader_directory.c
+++ b/src/myloader_directory.c
@@ -20,6 +20,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifdef ZWRAP_USE_ZSTD
 #include "../zstd/zstd_zlibwrapper.h"

--- a/src/myloader_jobs_manager.c
+++ b/src/myloader_jobs_manager.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "myloader_stream.h"
 #include "common.h"

--- a/src/myloader_process.c
+++ b/src/myloader_process.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <errno.h>
 #ifdef ZWRAP_USE_ZSTD

--- a/src/myloader_stream.c
+++ b/src/myloader_stream.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifdef ZWRAP_USE_ZSTD
 #include "../zstd/zstd_zlibwrapper.h"


### PR DESCRIPTION
Apparently newer Debian (and all Ubuntu) versions do not need this change, but Debian 8 and 9 do to be able to compile. I'm not sure if there's a reason not to change this, but it solves my problem. If there's a better way, please let me know (as I'm realy not the expert :-))

See https://github.com/Oefenweb/ansible-mydumper/pull/13/files