### PR TITLE
Backward compatibility for dump filenames

### DIFF
--- a/src/myloader_process.c
+++ b/src/myloader_process.c
@@ -243,18 +243,22 @@ void load_schema(struct db_table *dbt, gchar *filename){
 
 void get_database_table_part_name_from_filename(const gchar *filename, gchar **database, gchar **table, guint *part, guint *sub_part){
   guint l = strlen(filename)-4;
-  if (g_str_has_suffix(filename, compress_extension)){
+  if (g_str_has_suffix(filename, compress_extension)) {
     l-=strlen(compress_extension);
   }
-  gchar *f=g_strndup(filename,l);
+  gchar *f=g_strndup(filename, l);
   gchar **split_db_tbl = g_strsplit(f, ".", -1);
   g_free(f);
-  if (g_strv_length(split_db_tbl)>=3){
+  if (g_strv_length(split_db_tbl)>=3) {
     (*database)=g_strdup(split_db_tbl[0]);
     (*table)=g_strdup(split_db_tbl[1]);
-    *part=g_ascii_strtoull(split_db_tbl[2], NULL, 10);
+    if (g_strv_length(split_db_tbl)>=3) {
+      *part=g_ascii_strtoull(split_db_tbl[2], NULL, 10);
+    }else {
+      *part=0;
+    }
     if (g_strv_length(split_db_tbl)>3) *sub_part=g_ascii_strtoull(split_db_tbl[3], NULL, 10);
-  }else{
+  }else {
     *database=NULL;
     *table=NULL;
     *part=0;

--- a/src/myloader_process.c
+++ b/src/myloader_process.c
@@ -249,7 +249,7 @@ void get_database_table_part_name_from_filename(const gchar *filename, gchar **d
   gchar *f=g_strndup(filename, l);
   gchar **split_db_tbl = g_strsplit(f, ".", -1);
   g_free(f);
-  if (g_strv_length(split_db_tbl)>=3) {
+  if (g_strv_length(split_db_tbl)>=2) {
     (*database)=g_strdup(split_db_tbl[0]);
     (*table)=g_strdup(split_db_tbl[1]);
     if (g_strv_length(split_db_tbl)>=3) {


### PR DESCRIPTION
Old file names can also be exported without [.part].
This patch therefore implements a query to be able to import old exports as well.