### PR TITLE
NO_WRITE_TO_BINLOG added to FLUSH TABLES

### DIFF
--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -1008,7 +1008,7 @@ void start_dump() {
         send_lock_all_tables(conn);
       } else {
         g_message("Sending Flush Table");
-        if (mysql_query(conn, "FLUSH TABLES")) {
+        if (mysql_query(conn, "FLUSH NO_WRITE_TO_BINLOG TABLES")) {
           g_warning("Flush tables failed, we are continuing anyways: %s",
                    mysql_error(conn));
         }


### PR DESCRIPTION
NO_WRITE_TO_BINLOG added to FLUSH TABLES to avoid being written to the binlog