### PR TITLE
bypass table statistics cache when using --updated-since to fix #784

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -144,7 +144,7 @@ void load_session_hash_from_key_file(GKeyFile *kf, GHashTable * set_session_hash
   for (i=0; i < len; i++){
     value=g_key_file_get_value(kf,group_variables,keys[i],&error);
     if (!error)
-      g_hash_table_insert(set_session_hash, keys[i],value);
+      g_hash_table_insert(set_session_hash, keys[i], value);
   }
 }
 void load_anonymized_functions_from_key_file(GKeyFile *kf, GHashTable *all_anonymized_function, fun_ptr get_function_pointer_for()){
@@ -175,8 +175,15 @@ void refresh_set_session_from_hash(GString *ss, GHashTable * set_session_hash){
   gchar * lkey;
   g_hash_table_iter_init ( &iter, set_session_hash );
   gchar *e=NULL;
+  gchar *c=NULL;
   while ( g_hash_table_iter_next ( &iter, (gpointer *) &lkey, (gpointer *) &e ) ) {
-    g_string_append_printf(ss,"SET SESSION %s = %s ;\n",lkey,e);
+    c=g_strstr_len(e,strlen(e),"/*!");
+    if (c!=NULL){
+      c[0]='\0';
+      c++;
+      g_string_append_printf(ss,"/%s SET SESSION %s = %s */;\n",c,lkey,e);
+    }else
+      g_string_append_printf(ss,"SET SESSION %s = %s ;\n",lkey,e);
   }
 }
 

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -490,6 +490,13 @@ void get_not_updated(MYSQL *conn, FILE *file) {
   MYSQL_RES *res = NULL;
   MYSQL_ROW row;
 
+  if (detected_server == SERVER_TYPE_MYSQL &&
+      mysql_query(conn, "/*!80003 SET SESSION information_schema_stats_expiry=0 */"))
+  {
+    g_critical("Failed to set information_schema_stats_expiry, some tables may be missing: %s", mysql_error(conn));
+    errors++;
+  }
+
   gchar *query =
       g_strdup_printf("SELECT CONCAT(TABLE_SCHEMA,'.',TABLE_NAME) FROM "
                       "information_schema.TABLES WHERE TABLE_TYPE = 'BASE "

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -496,13 +496,6 @@ void get_not_updated(MYSQL *conn, FILE *file) {
   MYSQL_RES *res = NULL;
   MYSQL_ROW row;
 
-  if (detected_server == SERVER_TYPE_MYSQL &&
-      mysql_query(conn, "/*!80003 SET SESSION information_schema_stats_expiry=0 */"))
-  {
-    g_critical("Failed to set information_schema_stats_expiry, some tables may be missing: %s", mysql_error(conn));
-    errors++;
-  }
-
   gchar *query =
       g_strdup_printf("SELECT CONCAT(TABLE_SCHEMA,'.',TABLE_NAME) FROM "
                       "information_schema.TABLES WHERE TABLE_TYPE = 'BASE "

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -450,6 +450,12 @@ void *signal_thread(void *data) {
 }
 
 
+GHashTable * mydumper_initialize_hash_of_session_variables(){
+  GHashTable * set_session_hash=initialize_hash_of_session_variables();
+  g_hash_table_insert(set_session_hash,g_strdup("information_schema_stats_expiry"),g_strdup("0 /*!80003"));
+  return set_session_hash;
+}
+
 MYSQL *create_main_connection() {
   MYSQL *conn;
   conn = mysql_init(NULL);
@@ -458,7 +464,7 @@ MYSQL *create_main_connection() {
 
   set_session = g_string_new(NULL);
   detected_server = detect_server(conn);
-  GHashTable * set_session_hash = initialize_hash_of_session_variables();
+  GHashTable * set_session_hash = mydumper_initialize_hash_of_session_variables();
   if (key_file != NULL ){
     load_session_hash_from_key_file(key_file,set_session_hash,"mydumper_variables");
     load_anonymized_functions_from_key_file(key_file, all_anonymized_function, &get_function_pointer_for);


### PR DESCRIPTION
using --updated-since would miss some tables with stale TABLES.UPDATE_TIME since MySQL8.0, fix issue mydumper/mydumper#784

Just bypass table statistics cache with session variable information_schema_stats_expiry which introduced since 8.0.3:
/*!80003 SET SESSION information_schema_stats_expiry=0 */
