### PR TITLE
Harmonised integer types for table rows to guint64

### DIFF
--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -118,7 +118,7 @@ void write_table_metadata_into_file(struct db_table * dbt){
     g_critical("Couldn't write table metadata file %s (%d)", filename, errno);
     exit(EXIT_FAILURE);
   }
-  fprintf(table_meta, "%llu", dbt->rows);
+  fprintf(table_meta, "%"G_GUINT64_FORMAT, dbt->rows);
   fclose(table_meta);
   if (stream) g_async_queue_push(stream_queue, g_strdup(filename));
 }

--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -118,7 +118,7 @@ void write_table_metadata_into_file(struct db_table * dbt){
     g_critical("Couldn't write table metadata file %s (%d)", filename, errno);
     exit(EXIT_FAILURE);
   }
-  fprintf(table_meta, "%d", dbt->rows);
+  fprintf(table_meta, "%llu", dbt->rows);
   fclose(table_meta);
   if (stream) g_async_queue_push(stream_queue, g_strdup(filename));
 }

--- a/src/mydumper_start_dump.h
+++ b/src/mydumper_start_dump.h
@@ -104,7 +104,7 @@ struct db_table {
   GString *select_fields;
   gboolean has_generated_fields;
   guint64 datalength;
-  guint rows;
+  guint64 rows;
   GMutex *rows_lock;
   GList *anonymized_function;
   gchar *where;


### PR DESCRIPTION
When working with large tables, I often found negative values in the table metadata files, it appears it was for table above 2^31 rows.  I harmonised the integer type to guint64.  Be aware I ran no tests (neither compiled) this change as it seems to be quite trivial.