### PR TITLE
[BUG] Fix macOS build

### DIFF
--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -84,13 +84,13 @@ find_path(MYSQL_INCLUDE_DIR mysql.h
 )
 
 set(TMP_MYSQL_LIBRARIES "")
-set(CMAKE_FIND_LIBRARY_SUFFIXES .so .lib .so.1 .dylib .a)
+set(CMAKE_FIND_LIBRARY_SUFFIXES .so .lib .so.1 .dylib .a .tbd)
 foreach(MY_LIB ${MYSQL_ADD_LIBRARIES})
     find_library("MYSQL_LIBRARIES_${MY_LIB}" NAMES ${MY_LIB}
         HINTS
         ${MYSQL_ADD_LIBRARY_PATH}
         /usr/lib/mysql
-	/usr/lib
+        /usr/lib
         /usr/local/lib
         /usr/local/lib/mysql
         /usr/local/mysql/lib

--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -90,9 +90,9 @@ void *process_stream(void *data){
         total_diff=g_date_time_difference(datetime,total_start_time)/G_TIME_SPAN_SECOND;
         g_date_time_unref(datetime);
         if (diff > 0){
-          g_message("File %s transferred in %" G_GINT64_FORMAT " seconds at %lld MB/s | Global: %lld MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+          g_message("File %s transferred in %" G_GINT64_FORMAT " seconds at %" G_GINT64_FORMAT " MB/s | Global: %" G_GINT64_FORMAT " MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }else{
-          g_message("File %s transferred | Global: %lld MB/s",filename,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+          g_message("File %s transferred | Global: %" G_GINT64_FORMAT "MB/s",filename,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }
         total_size+=total_len;
         fclose(f);

--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -90,9 +90,9 @@ void *process_stream(void *data){
         total_diff=g_date_time_difference(datetime,total_start_time)/G_TIME_SPAN_SECOND;
         g_date_time_unref(datetime);
         if (diff > 0){
-          g_message("File %s transferred in %ld seconds at %ld MB/s | Global: %ld MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+          g_message("File %s transferred in %lld seconds at %lld MB/s | Global: %lld MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }else{
-          g_message("File %s transferred | Global: %ld MB/s",filename,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+          g_message("File %s transferred | Global: %lld MB/s",filename,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }
         total_size+=total_len;
         fclose(f);
@@ -108,7 +108,7 @@ void *process_stream(void *data){
   total_diff=g_date_time_difference(datetime,total_start_time)/G_TIME_SPAN_SECOND;
   g_date_time_unref(total_start_time);
   g_date_time_unref(datetime);
-  g_message("All data transferred was %ld at a rate of %ld MB/s",total_size,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+  g_message("All data transferred was %lld at a rate of %lld MB/s",total_size,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
   return NULL;
 }
 

--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -90,7 +90,7 @@ void *process_stream(void *data){
         total_diff=g_date_time_difference(datetime,total_start_time)/G_TIME_SPAN_SECOND;
         g_date_time_unref(datetime);
         if (diff > 0){
-          g_message("File %s transferred in %lld seconds at %lld MB/s | Global: %lld MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+          g_message("File %s transferred in %" G_GINT64_FORMAT " seconds at %lld MB/s | Global: %lld MB/s",filename,diff,total_len/1024/1024/diff,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }else{
           g_message("File %s transferred | Global: %lld MB/s",filename,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
         }
@@ -108,7 +108,7 @@ void *process_stream(void *data){
   total_diff=g_date_time_difference(datetime,total_start_time)/G_TIME_SPAN_SECOND;
   g_date_time_unref(total_start_time);
   g_date_time_unref(datetime);
-  g_message("All data transferred was %lld at a rate of %lld MB/s",total_size,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
+  g_message("All data transferred was %" G_GINT64_FORMAT " at a rate of %" G_GINT64_FORMAT " MB/s",total_size,total_diff!=0?total_size/1024/1024/total_diff:total_size/1024/1024);
   return NULL;
 }
 

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -345,7 +345,8 @@ void write_load_data_column_into_string( MYSQL *conn, gchar **column, MYSQL_FIEL
     }else if (field.type != MYSQL_TYPE_LONG && field.type != MYSQL_TYPE_LONGLONG  && field.type != MYSQL_TYPE_INT24  && field.type != MYSQL_TYPE_SHORT ){
       g_string_append(statement_row,fields_enclosed_by);
       g_string_set_size(escaped, length * 2 + 1);
-      mysql_real_escape_string(conn, escaped->str, fun_ptr_i->function(column,fun_ptr_i->memory), length);
+      unsigned long new_length = mysql_real_escape_string(conn, escaped->str, fun_ptr_i->function(column,fun_ptr_i->memory), length);
+      g_string_set_size(escaped, new_length);
       m_replace_char_with_char('\\',*fields_escaped_by,escaped->str,escaped->len);
       m_escape_char_with_char(*fields_terminated_by, *fields_escaped_by, escaped->str,escaped->len);
       g_string_append(statement_row,escaped->str);

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -187,7 +187,7 @@ gchar * print_time(GTimeSpan timespan){
   GTimeSpan hours  =(timespan-(days*G_TIME_SPAN_DAY))/G_TIME_SPAN_HOUR;
   GTimeSpan minutes=(timespan-(days*G_TIME_SPAN_DAY)-(hours*G_TIME_SPAN_HOUR))/G_TIME_SPAN_MINUTE;
   GTimeSpan seconds=(timespan-(days*G_TIME_SPAN_DAY)-(hours*G_TIME_SPAN_HOUR)-(minutes*G_TIME_SPAN_MINUTE))/G_TIME_SPAN_SECOND;
-  return g_strdup_printf("%lld %02lld:%02lld:%02lld",days,hours,minutes,seconds);
+  return g_strdup_printf("%" G_GINT64_FORMAT " %02" G_GINT64_FORMAT ":%02" G_GINT64_FORMAT ":%02" G_GINT64_FORMAT "",days,hours,minutes,seconds);
 }
 
 

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -187,7 +187,7 @@ gchar * print_time(GTimeSpan timespan){
   GTimeSpan hours  =(timespan-(days*G_TIME_SPAN_DAY))/G_TIME_SPAN_HOUR;
   GTimeSpan minutes=(timespan-(days*G_TIME_SPAN_DAY)-(hours*G_TIME_SPAN_HOUR))/G_TIME_SPAN_MINUTE;
   GTimeSpan seconds=(timespan-(days*G_TIME_SPAN_DAY)-(hours*G_TIME_SPAN_HOUR)-(minutes*G_TIME_SPAN_MINUTE))/G_TIME_SPAN_SECOND;
-  return g_strdup_printf("%ld %02ld:%02ld:%02ld",days,hours,minutes,seconds);
+  return g_strdup_printf("%lld %02lld:%02lld:%02lld",days,hours,minutes,seconds);
 }
 
 


### PR DESCRIPTION
## Description
👋  This PR fixes two issues: compiling the project on macOS Ventura was failing due to the new `.tbd` stub system library files that replace `.dylib`s. Since `FindMySQL.cmake` hardcodes `CMAKE_FIND_LIBRARY_SUFFIXES`, I had to add that extra library filetype in there; If it works for everyone I can just remove that and have it use the default (which should work everywhere)

There were also a couple of compilation warnings turned into failures regarding format strings using `%ld` for `GTimeSpan`s, which are long long ints and require `%lld`