### PR TITLE
validate thread count cli options

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -29,6 +29,8 @@ extern gchar *defaults_file;
 extern GKeyFile * key_file;
 extern gboolean no_stream;
 
+extern guint num_threads;
+
 FILE * (*m_open)(const char *filename, const char *);
 GAsyncQueue *stream_queue = NULL;
 extern int detected_server;
@@ -430,3 +432,10 @@ gboolean stream_arguments_callback(const gchar *option_name,const gchar *value, 
   return FALSE;
 }
 
+void check_num_threads()
+{
+  if (num_threads < MIN_THREAD_COUNT) {
+    g_warning("invalid number of threads %d, setting to %d", num_threads, MIN_THREAD_COUNT);
+    num_threads = MIN_THREAD_COUNT;
+  }
+}

--- a/src/common.h
+++ b/src/common.h
@@ -65,3 +65,7 @@ void remove_definer_from_gchar(char * str);
 void print_version(const gchar *program);
 gboolean stream_arguments_callback(const gchar *option_name,const gchar *value, gpointer data, GError **error);
 #endif
+
+/* using fewer than 2 threads can cause mydumper to hang */
+#define MIN_THREAD_COUNT 2
+void check_num_threads();

--- a/src/mydumper.c
+++ b/src/mydumper.c
@@ -218,6 +218,9 @@ int main(int argc, char *argv[]) {
   if (tables_skiplist_file)
     read_tables_skiplist(tables_skiplist_file, &errors);
 
+  /* Validate that thread count passed on CLI is a valid count */
+  check_num_threads();
+
   if (daemon_mode) {
     run_daemon();
   } else {


### PR DESCRIPTION
there does not appear to be validation of the --threads or -t count passed into mydumper.  Invalid options like -1 cause the program to crash and valid but low thread counts like 0 or 1 cause the program to hang indefinately and in the case of 1 with a consistent backup cause the database to lock until the program is killed.  This change is a very simple approach to validating that the thread count is at least two or a warning is printed and the count set to 2.  Invalid types passed in like signed numbers will still cause mydumper to crash but not hang and potentially lock the database.