### PR TITLE
Do not set UNIQUE_CHECKS=0 for MariaDB

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -41,7 +41,7 @@ extern int detected_server;
 
 GHashTable * initialize_hash_of_session_variables(){
   GHashTable * set_session_hash=g_hash_table_new ( g_str_hash, g_str_equal );
-  if (detected_server == SERVER_TYPE_MYSQL){
+  if (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB){
     g_hash_table_insert(set_session_hash,g_strdup("WAIT_TIMEOUT"),g_strdup("2147483"));
     g_hash_table_insert(set_session_hash,g_strdup("NET_WRITE_TIMEOUT"),g_strdup("2147483"));
   }

--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -376,7 +376,7 @@ void update_integer_min(MYSQL *conn, struct table_job *tj){
   /* Get minimum/maximum */
   mysql_query(conn, query = g_strdup_printf(
                         "SELECT %s `%s` FROM `%s`.`%s` WHERE %s %"G_GUINT64_FORMAT" <= `%s` AND `%s` <= %"G_GUINT64_FORMAT" ORDER BY `%s` ASC LIMIT 1",
-                        (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */": "",
+                        (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */": "",
                         tj->dbt->field, tj->dbt->database->name, tj->dbt->table, cs->integer_step.prefix,  cs->integer_step.nmin, tj->dbt->field, tj->dbt->field, cs->integer_step.nmax, tj->dbt->field));
   g_free(query);
   minmax = mysql_store_result(conn);
@@ -403,7 +403,7 @@ void update_integer_max(MYSQL *conn, struct table_job *tj){
   /* Get minimum/maximum */
   mysql_query(conn, query = g_strdup_printf(
                         "SELECT %s `%s` FROM `%s`.`%s` WHERE %"G_GUINT64_FORMAT" <= `%s` AND `%s` <= %"G_GUINT64_FORMAT" ORDER BY `%s` DESC LIMIT 1",
-                        (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */": "",
+                        (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */": "",
                         tj->dbt->field, tj->dbt->database->name, tj->dbt->table, cs->integer_step.nmin, tj->dbt->field, tj->dbt->field, cs->integer_step.nmax, tj->dbt->field));
 //  g_free(query);
   minmax = mysql_store_result(conn);
@@ -436,7 +436,7 @@ gchar* update_cursor (MYSQL *conn, struct table_job *tj){
   gchar * middle = get_escaped_middle_char(conn, cs->char_step.cmax, cs->char_step.cmax_clen, cs->char_step.cmin, cs->char_step.cmin_clen, tj->char_chunk_part>0?tj->char_chunk_part:1);//num_threads*(num_threads - cs->char_step.deep>0?num_threads-cs->char_step.deep:1));
   mysql_query(conn, query = g_strdup_printf(
                         "SELECT %s `%s` FROM `%s`.`%s` WHERE '%s' <= `%s` AND '%s' <= `%s` AND `%s` <= '%s' ORDER BY `%s` LIMIT 1",
-                        (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */": "",
+                        (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */": "",
                         tj->dbt->field, tj->dbt->database->name, tj->dbt->table, cs->char_step.cmin_escaped, tj->dbt->field, middle, tj->dbt->field, tj->dbt->field, cs->char_step.cmax_escaped, tj->dbt->field));
   g_free(query);
   minmax = mysql_store_result(conn);
@@ -492,7 +492,7 @@ gboolean get_new_minmax (struct thread_data *td, struct db_table *dbt, union chu
 //  g_message("Middle point: `%s` | `%c` %u", middle, middle[0], d);
   mysql_query(td->thrconn, query = g_strdup_printf(
                         "SELECT %s `%s` FROM `%s`.`%s` WHERE `%s` > (SELECT `%s` FROM `%s`.`%s` WHERE `%s` > '%s' ORDER BY `%s` LIMIT 1) AND '%s' < `%s` AND `%s` < '%s' ORDER BY `%s` LIMIT 1",
-                        (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */": "",
+                        (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */": "",
                         dbt->field, dbt->database->name, dbt->table, dbt->field, dbt->field, dbt->database->name, dbt->table, dbt->field, middle, dbt->field, previous->char_step.cursor_escaped!=NULL?previous->char_step.cursor_escaped:previous->char_step.cmin_escaped, dbt->field, dbt->field, previous->char_step.cmax_escaped, dbt->field));
   g_free(query);
   minmax = mysql_store_result(td->thrconn);
@@ -557,7 +557,7 @@ void set_chunk_strategy_for_dbt(MYSQL *conn, struct db_table *dbt){
   /* Get minimum/maximum */
   mysql_query(conn, query = g_strdup_printf(
                         "SELECT %s MIN(`%s`),MAX(`%s`),LEFT(MIN(`%s`),1),LEFT(MAX(`%s`),1) FROM `%s`.`%s` %s %s",
-                        (detected_server == SERVER_TYPE_MYSQL)
+                        (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB)
                             ? "/*!40001 SQL_NO_CACHE */"
                             : "",
                         dbt->field, dbt->field, dbt->field, dbt->field, dbt->database->name, dbt->table, where_option ? "WHERE" : "", where_option ? where_option : ""));

--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -322,7 +322,7 @@ void determine_ecol_ccol(MYSQL_RES *result, guint *ecol, guint *ccol, guint *col
 }
 
 void initialize_sql_statement(GString *statement){
-  if (detected_server == SERVER_TYPE_MYSQL) {
+  if ((detected_server == SERVER_TYPE_MYSQL) || (detected_server == SERVER_TYPE_MARIADB))  {
     if (set_names_statement)
       g_string_printf(statement,"%s;\n",set_names_statement);
     g_string_append(statement, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\n");

--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -167,7 +167,7 @@ void write_table_metadata_into_file(struct db_table * dbt){
 }
 
 gchar * get_tablespace_query(){
-  if ( get_product() == SERVER_TYPE_PERCONA || get_product() == SERVER_TYPE_MYSQL){
+  if ( get_product() == SERVER_TYPE_PERCONA || get_product() == SERVER_TYPE_MYSQL ){
     if ( get_major() == 5 && get_secondary() == 7)
       return g_strdup("select NAME, PATH, FS_BLOCK_SIZE from information_schema.INNODB_SYS_TABLESPACES join information_schema.INNODB_SYS_DATAFILES using (space) where SPACE_TYPE='General' and NAME != 'mysql';");
     if ( get_major() == 8 )
@@ -429,7 +429,7 @@ void write_view_definition_into_file(MYSQL *conn, char *database, char *table, c
     return;
   }
 
-  if (detected_server == SERVER_TYPE_MYSQL && set_names_statement) {
+  if ((detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) && set_names_statement) {
     g_string_printf(statement,"%s;\n",set_names_statement);
   }
 

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -424,6 +424,10 @@ MYSQL *create_main_connection() {
     g_message("Connected to a MySQL server");
     set_transaction_isolation_level_repeatable_read(conn);
     break;
+  case SERVER_TYPE_MARIADB:
+    g_message("Connected to a MariaDB server");
+    set_transaction_isolation_level_repeatable_read(conn);
+    break;
   case SERVER_TYPE_DRIZZLE:
     g_message("Connected to a Drizzle server");
     break;
@@ -974,7 +978,7 @@ void start_dump() {
   g_mutex_lock(ready_table_dump_mutex);
 
 
-  if (detected_server == SERVER_TYPE_MYSQL) {
+  if (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) {
     create_job_to_dump_metadata(&conf, mdfile);
   }
 

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -435,8 +435,15 @@ void get_table_info_to_process_from_list(MYSQL *conn, struct configuration *conf
   for (x = 0; table_list[x] != NULL; x++) {
     dt = g_strsplit(table_list[x], ".", 0);
 
-    query =
-        g_strdup_printf("SHOW TABLE STATUS FROM %s LIKE '%s'", dt[0], dt[1]);
+    // Need 7 columns with DATA_LENGTH as the last one for this to work
+    if (detected_server == SERVER_TYPE_MARIADB)
+      query =
+          g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT, TABLE_COLLATION as COLLATION, AVG_ROW_LENGTH, DATA_LENGTH FROM "
+                          "INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s' AND TABLE_NAME='%s'",
+                          dt[0], dt[1]);
+    else
+      query =
+          g_strdup_printf("SHOW TABLE STATUS FROM %s LIKE '%s'", dt[0], dt[1]);
 
     if (mysql_query(conn, (query))) {
       g_critical("Error showing table status on: %s - Could not execute query: %s", dt[0],
@@ -1541,7 +1548,7 @@ void dump_database_thread(MYSQL *conn, struct configuration *conf, struct databa
     query = g_strdup("SHOW TABLE STATUS");
   else if (detected_server == SERVER_TYPE_MARIADB)
     query =
-        g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT FROM "
+        g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT, TABLE_COLLATION as COLLATION, AVG_ROW_LENGTH, DATA_LENGTH FROM "
                         "INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s'",
                         database->escaped);
   else

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -473,7 +473,8 @@ void get_table_info_to_process_from_list(MYSQL *conn, struct configuration *conf
 
       int is_view = 0;
 
-      if ((detected_server == SERVER_TYPE_MYSQL) &&
+      if ((detected_server == SERVER_TYPE_MYSQL ||
+           detected_server == SERVER_TYPE_MARIADB) &&
           (row[ccol] == NULL || !strcmp(row[ccol], "VIEW")))
         is_view = 1;
 
@@ -1538,6 +1539,11 @@ void dump_database_thread(MYSQL *conn, struct configuration *conf, struct databa
   if (detected_server == SERVER_TYPE_MYSQL ||
       detected_server == SERVER_TYPE_TIDB)
     query = g_strdup("SHOW TABLE STATUS");
+  else if (detected_server == SERVER_TYPE_MARIADB)
+    query =
+        g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT FROM "
+                        "INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s'",
+                        database->escaped);
   else
     query =
         g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT FROM "
@@ -1574,7 +1580,8 @@ void dump_database_thread(MYSQL *conn, struct configuration *conf, struct databa
        TABLE STATUS row[1] == NULL if it is a view in 5.0 'SHOW TABLE STATUS'
             row[1] == "VIEW" if it is a view in 5.0 'SHOW FULL TABLES'
     */
-    if ((detected_server == SERVER_TYPE_MYSQL) &&
+    if ((detected_server == SERVER_TYPE_MYSQL ||
+         detected_server == SERVER_TYPE_MARIADB) &&
         (row[ccol] == NULL || !strcmp(row[ccol], "VIEW")))
       is_view = 1;
 

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -668,7 +668,7 @@ guint64 write_table_data_into_file(MYSQL *conn, struct table_job * tj){
   /* Poor man's database code */
   query = g_strdup_printf(
       "SELECT %s %s FROM `%s`.`%s` %s %s %s %s %s %s %s %s %s %s %s",
-      (detected_server == SERVER_TYPE_MYSQL) ? "/*!40001 SQL_NO_CACHE */" : "",
+      (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */" : "",
       tj->dbt->select_fields->str,
       tj->dbt->database->name, tj->dbt->table, tj->partition?tj->partition:"",
        (tj->where || where_option   || tj->dbt->where) ? "WHERE"  : "" ,      tj->where ?      tj->where : "",

--- a/src/myloader_jobs_manager.c
+++ b/src/myloader_jobs_manager.c
@@ -22,6 +22,7 @@
 #include <string.h>
 #include "myloader_stream.h"
 #include "common.h"
+#include "server_detect.h"
 #include "myloader.h"
 #include "myloader_common.h"
 #include "myloader_process.h"
@@ -40,6 +41,7 @@ extern guint num_threads;
 extern gboolean stream;
 extern guint max_threads_for_index_creation;
 extern gboolean innodb_optimize_keys_all_tables;
+extern int detected_server;
 static GMutex *init_mutex=NULL;
 static GMutex *index_mutex=NULL;
 guint index_threads_counter = 0;
@@ -116,7 +118,11 @@ void *loader_thread(struct thread_data *td) {
 
 //  mysql_query(td->thrconn, set_names_statement);
   mysql_query(td->thrconn, "/*!40101 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */");
-  mysql_query(td->thrconn, "/*!40014 SET UNIQUE_CHECKS=0 */");
+  if (detected_server != SERVER_TYPE_MARIADB) {
+    // This causes MariaDB to add table locks which accelerate single-threaded
+    // insertion, at the cost of multi-threaded performance insertion.
+    mysql_query(td->thrconn, "/*!40014 SET UNIQUE_CHECKS=0 */");
+  }
   mysql_query(td->thrconn, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/");
 
   execute_gstring(td->thrconn, set_session);

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -76,7 +76,7 @@ int detect_server(MYSQL *conn) {
   pcre_free(re);
 
   if (rc > 0) {
-    return SERVER_TYPE_MYSQL;
+    return SERVER_TYPE_MARIADB;
   }
 
   return SERVER_TYPE_UNKNOWN;


### PR DESCRIPTION
`UNIQUE_CHECKS=0` sets MariaDB into a special mode that adds table level
locks for InnoDB. This accelerates single-threaded insert performance,
but makes multi-threaded into one table much slower.

This also adds a patch to fix the MariaDB type and version check.

Fixes #987 