### PR TITLE
Adding /etc/mydumper.cnf as default file

### DIFF
--- a/mydumper.cnf
+++ b/mydumper.cnf
@@ -1,0 +1,30 @@
+[mydumper_session_variables]
+# wait_timeout = 300
+# sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
+
+[mydumper_global_variables]
+#sync_binlog = 0
+#slow_query_log = OFF
+
+[myloader_session_variables]
+SQL_MODE='NO_AUTO_VALUE_ON_ZERO' /*!40101
+UNIQUE_CHECKS=0 /*!40114
+FOREIGN_KEY_CHECKS=0 /*!40114
+sync_binlog = 0
+innodb_flush_log_at_trx_commit = 0
+
+[myloader_session_variables_mariadb_10_6]
+SQL_MODE='NO_AUTO_VALUE_ON_ZERO' /*!40101
+UNIQUE_CHECKS=1 /*!40114
+FOREIGN_KEY_CHECKS=0 /*!40114
+
+[myloader_global_variables]
+#sync_binlog = 0
+#innodb_flush_log_at_trx_commit = 0
+
+
+
+[myloader_session_variables_percona_5_8]
+SQL_MODE='NO_AUTO_VALUE_ON_ZERO' /*!40101
+UNIQUE_CHECKS=1 /*!40114
+FOREIGN_KEY_CHECKS=0 /*!40114

--- a/package/deb/files
+++ b/package/deb/files
@@ -5,3 +5,4 @@ cd $SOURCE
 install -m 0755 -d ${BUILD_ROOT}/usr/bin/
 install -m 0555 mydumper ${BUILD_ROOT}/usr/bin/
 install -m 0555 myloader ${BUILD_ROOT}/usr/bin/
+install -m 0554 mydumper.cnf ${BUILD_ROOT}/etc/

--- a/package/rpm/mydumper-zstd.spec
+++ b/package/rpm/mydumper-zstd.spec
@@ -33,6 +33,7 @@ myloader is a tool used for multi-threaded restoration of mydumper backups.
 install -m 0755 -d ${RPM_BUILD_ROOT}%{_bindir}
 install -m 0755 mydumper ${RPM_BUILD_ROOT}%{_bindir}
 install -m 0755 myloader ${RPM_BUILD_ROOT}%{_bindir}
+install -m 0554 mydumper.cnf ${RPM_BUILD_ROOT}%{_sysconfdir}
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}

--- a/package/rpm/mydumper.spec
+++ b/package/rpm/mydumper.spec
@@ -32,6 +32,7 @@ myloader is a tool used for multi-threaded restoration of mydumper backups.
 install -m 0755 -d ${RPM_BUILD_ROOT}%{_bindir}
 install -m 0755 mydumper ${RPM_BUILD_ROOT}%{_bindir}
 install -m 0755 myloader ${RPM_BUILD_ROOT}%{_bindir}
+install -m 0554 mydumper.cnf ${RPM_BUILD_ROOT}%{_sysconfdir}
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}

--- a/src/common.h
+++ b/src/common.h
@@ -29,6 +29,7 @@ struct configuration_per_table{
 };
 
 #define STREAM_BUFFER_SIZE 1000000
+#define DEFAULTS_FILE "/etc/mydumper.cnf"
 typedef gchar * (*fun_ptr)(gchar **, GHashTable *);
 
 struct function_pointer{
@@ -52,7 +53,7 @@ void load_config_group(GKeyFile *kf, GOptionContext *context, const gchar * grou
 void execute_gstring(MYSQL *conn, GString *ss);
 gchar *replace_escaped_strings(gchar *c);
 void escape_tab_with(gchar *to);
-void load_session_hash_from_key_file(GKeyFile *kf, GHashTable * set_session_hash, const gchar * group_variables);
+void load_hash_from_key_file(GKeyFile *kf, GHashTable * set_session_hash, const gchar * group_variables);
 //void load_anonymized_functions_from_key_file(GKeyFile *kf, GHashTable *all_anonymized_function, fun_ptr get_function_pointer_for());
 void load_per_table_info_from_key_file(GKeyFile *kf, struct configuration_per_table * conf_per_table, fun_ptr get_function_pointer_for());
 void refresh_set_session_from_hash(GString *ss, GHashTable * set_session_hash);
@@ -77,3 +78,5 @@ void check_num_threads();
 
 void m_error(const char *fmt, ...);
 void m_critical(const char *fmt, ...);
+
+void load_hash_of_all_variables_perproduct_from_key_file(GKeyFile *kf, GHashTable * set_session_hash, const gchar *str);

--- a/src/common_options.h
+++ b/src/common_options.h
@@ -66,7 +66,7 @@ GOptionEntry common_entries[] = {
      "(automatically sets verbosity to 3)", NULL},
 #endif
     {"defaults-file", 0, 0, G_OPTION_ARG_FILENAME, &defaults_file,
-     "Use a specific defaults file", NULL},
+     "Use a specific defaults file. Default: /etc/mydumper.cnf", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 

--- a/src/mydumper.c
+++ b/src/mydumper.c
@@ -165,9 +165,7 @@ int main(int argc, char *argv[]) {
   } else {
     set_verbose(verbose);
   }
-  gchar *mydumper = g_strdup("mydumper");
-  initialize_common_options(context, mydumper);
-  g_free(mydumper);
+  initialize_common_options(context, "mydumper");
   g_option_context_free(context);
 
   initialize_main();

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -93,7 +93,6 @@ extern gboolean load_data;
 extern gboolean stream;
 extern int detected_server;
 extern gboolean no_delete;
-extern char *defaults_file;
 extern FILE * (*m_open)(const char *filename, const char *);
 extern int (*m_close)(void *file);
 extern int (*m_write)(FILE * file, const char * buff, int len);
@@ -408,8 +407,8 @@ MYSQL *create_main_connection() {
   GHashTable * set_session_hash = mydumper_initialize_hash_of_session_variables();
   GHashTable * set_global_hash = g_hash_table_new ( g_str_hash, g_str_equal );
   if (key_file != NULL ){
-    load_session_hash_from_key_file(key_file,set_session_hash,"mydumper_session_variables");
-    load_session_hash_from_key_file(key_file,set_global_hash,"mydumper_global_variables");
+    load_hash_of_all_variables_perproduct_from_key_file(key_file,set_global_hash,"mydumper_global_variables");
+    load_hash_of_all_variables_perproduct_from_key_file(key_file,set_session_hash,"mydumper_session_variables");
     load_per_table_info_from_key_file(key_file, &conf_per_table, &get_function_pointer_for);
   }
   refresh_set_session_from_hash(set_session,set_session_hash);

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -419,8 +419,8 @@ int main(int argc, char *argv[]) {
   GHashTable * set_session_hash = myloader_initialize_hash_of_session_variables();
   GHashTable * set_global_hash = g_hash_table_new ( g_str_hash, g_str_equal );
   if (defaults_file){
-    load_session_hash_from_key_file(key_file,set_global_hash,"myloader_global_variables");
-    load_session_hash_from_key_file(key_file,set_session_hash,"myloader_session_variables");
+    load_hash_of_all_variables_perproduct_from_key_file(key_file,set_global_hash,"myloader_global_variables");
+    load_hash_of_all_variables_perproduct_from_key_file(key_file,set_session_hash,"myloader_session_variables");
   }
   refresh_set_session_from_hash(set_session,set_session_hash);
   refresh_set_global_from_hash(set_global,set_global_back, set_global_hash);

--- a/src/myloader_jobs_manager.c
+++ b/src/myloader_jobs_manager.c
@@ -115,9 +115,9 @@ void *loader_thread(struct thread_data *td) {
   m_connect(td->thrconn, "myloader", NULL);
 
 //  mysql_query(td->thrconn, set_names_statement);
-  mysql_query(td->thrconn, "/*!40101 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */");
-  mysql_query(td->thrconn, "/*!40014 SET UNIQUE_CHECKS=0 */");
-  mysql_query(td->thrconn, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/");
+//  mysql_query(td->thrconn, "/*!40101 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */");
+//  mysql_query(td->thrconn, "/*!40014 SET UNIQUE_CHECKS=0 */");
+//  mysql_query(td->thrconn, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/");
 
   execute_gstring(td->thrconn, set_session);
   g_async_queue_push(conf->ready, GINT_TO_POINTER(1));

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -122,3 +122,18 @@ int get_secondary(){
 int get_revision(){
       return revision;
 }
+
+const gchar * get_product_name(){
+  switch (get_product()){
+  case SERVER_TYPE_PERCONA: return "percona"; break;
+  case SERVER_TYPE_MYSQL: return "mysql"; break;
+  case SERVER_TYPE_MARIADB: return "mariadb"; break;
+  default: return "";
+}
+
+
+}
+
+
+
+

--- a/src/server_detect.h
+++ b/src/server_detect.h
@@ -38,6 +38,7 @@ int get_product();
 int get_major();
 int get_secondary();
 int get_revision();
+const gchar * get_product_name();
 #endif
 
 

--- a/test_mydumper.sh
+++ b/test_mydumper.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-empty="/tmp/empty"
 mydumper_log="/tmp/test_mydumper.log"
 tmp_mydumper_log="/tmp/test_mydumper.log.tmp"
 myloader_log="/tmp/test_myloader.log"
@@ -10,6 +9,7 @@ stream_stor_dir="/tmp/stream_data"
 mydumper_base="."
 mydumper="${mydumper_base}/mydumper"
 myloader="${mydumper_base}/myloader"
+configfile="${mydumper_base}/mydumper.cnf"
 > $mydumper_log
 > $myloader_log
 for i in $*
@@ -24,8 +24,9 @@ do
   fi
 done
 
-echo "[mydumper]" > $empty
-echo "[myloader]" >> $empty
+#echo "[mydumper]" > $configfile
+#echo "[myloader]" >> $configfile
+
 test_case_dir (){
   # Test case
   # We should consider each test case, with different mydumper/myloader parameters
@@ -41,12 +42,12 @@ test_case_dir (){
     mkdir -p ${mydumper_stor_dir}
     # Export
     echo "Exporting database: ${mydumper_parameters}"
-    eval $mydumper --defaults-file="$empty" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters}
+    eval $mydumper --defaults-file="$configfile" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters}
     error=$?
     cat $tmp_mydumper_log >> $mydumper_log
     if (( $error > 0 ))
     then
-      echo "Error running: $mydumper --defaults-file="$empty" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
+      echo "Error running: $mydumper --defaults-file="$configfile" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
       cat $tmp_mydumper_log
       exit $error
     fi
@@ -63,13 +64,13 @@ DROP DATABASE IF EXISTS empty_db;" | mysql --no-defaults -f -h 127.0.0.1 -u root
     # Import
     echo "Importing database: ${myloader_parameters}"
 
-    eval $myloader --defaults-file="$empty" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters}
+    eval $myloader --defaults-file="$configfile" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters}
     error=$?
     cat $tmp_myloader_log >> $myloader_log
     if (( $error > 0 ))
     then
-      echo "Error running: $myloader --defaults-file="$empty" -u root -v 4 -L $myloader_log ${myloader_parameters}"
-      echo "Error running myloader with mydumper: $mydumper --defaults-file="$empty" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
+      echo "Error running: $myloader --defaults-file="$configfile" -u root -v 4 -L $myloader_log ${myloader_parameters}"
+      echo "Error running myloader with mydumper: $mydumper --defaults-file="$configfile" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
       cat $tmp_myloader_log
       exit $error
     fi
@@ -91,16 +92,16 @@ test_case_stream (){
     rm -rf ${mydumper_stor_dir} ${myloader_stor_dir}
     mkdir -p ${mydumper_stor_dir} ${myloader_stor_dir}
     # Export
-    echo "Exporting database: $mydumper --stream --defaults-file="$empty" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters} | $myloader --defaults-file="$empty" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters} --stream"
-    eval $mydumper --stream --defaults-file="$empty" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters} > /tmp/stream.sql
-    cat /tmp/stream.sql | $myloader --defaults-file="$empty" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters} --stream
+    echo "Exporting database: $mydumper --stream --defaults-file="$configfile" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters} | $myloader --defaults-file="$configfile" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters} --stream"
+    eval $mydumper --stream --defaults-file="$configfile" -u root -M -v 4 -L $tmp_mydumper_log ${mydumper_parameters} > /tmp/stream.sql
+    cat /tmp/stream.sql | $myloader --defaults-file="$configfile" -u root -v 4 -L $tmp_myloader_log ${myloader_parameters} --stream
     error=$?
     cat $tmp_myloader_log >> $myloader_log
     cat $tmp_mydumper_log >> $mydumper_log
     if (( $error > 0 ))
     then
-      echo "Error running: $mydumper --stream --defaults-file="$empty" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
-      echo "Error running: $myloader --defaults-file="$empty" -u root -v 4 -L $myloader_log ${myloader_parameters} --stream"
+      echo "Error running: $mydumper --stream --defaults-file="$configfile" -u root -M -v 4 -L $mydumper_log ${mydumper_parameters}"
+      echo "Error running: $myloader --defaults-file="$configfile" -u root -v 4 -L $myloader_log ${myloader_parameters} --stream"
       cat $tmp_mydumper_log
       cat $tmp_myloader_log
       exit $error


### PR DESCRIPTION
This will allow use to set at config level specific configurations for different vendors and versions #987, adding particular sections, for instance:
```
[myloader_session_variables_mariadb_10_6]
SQL_MODE='NO_AUTO_VALUE_ON_ZERO' /*!40101
UNIQUE_CHECKS=1 /*!40114
FOREIGN_KEY_CHECKS=0 /*!40114
```
We are appending/replacing variables on this order of sections:
1.  `myloader_session_variables`
2. `myloader_session_variables_[VENDOR]`
3. `myloader_session_variables_[VENDOR]_[MAJOR]`
4. `myloader_session_variables_[VENDOR]_[MAJOR]_[SECONDARY]`
5. `myloader_session_variables_[VENDOR]_[MAJOR]_[SECONDARY]_[REVISION]`

The vendors supported so far are: mariadb, percona and mysql. As I'm still working on the test on tidb, it was not added yet, but we might do it in the near future.