### PR TITLE
Remove Drizzle support

### DIFF
--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -427,9 +427,6 @@ MYSQL *create_main_connection() {
     g_message("Connected to a MariaDB server");
     set_transaction_isolation_level_repeatable_read(conn);
     break;
-  case SERVER_TYPE_DRIZZLE:
-    g_message("Connected to a Drizzle server");
-    break;
   case SERVER_TYPE_TIDB:
     g_message("Connected to a TiDB server");
     break;

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -1552,10 +1552,7 @@ void dump_database_thread(MYSQL *conn, struct configuration *conf, struct databa
                         "INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='%s'",
                         database->escaped);
   else
-    query =
-        g_strdup_printf("SELECT TABLE_NAME, ENGINE, TABLE_TYPE as COMMENT FROM "
-                        "DATA_DICTIONARY.TABLES WHERE TABLE_SCHEMA='%s'",
-                        database->escaped);
+      return;
 
   if (mysql_query(conn, (query))) {
       g_critical("Error showing tables on: %s - Could not execute query: %s", database->name,

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -55,18 +55,6 @@ int detect_server(MYSQL *conn) {
     return SERVER_TYPE_MYSQL;
   }
 
-  re = pcre_compile(DETECT_DRIZZLE_REGEX, 0, &error, &erroroffset, NULL);
-  if (!re) {
-    m_critical("Regular expression fail: %s", error);
-  }
-
-  rc = pcre_exec(re, NULL, db_version, strlen(db_version), 0, 0, ovector, 9);
-  pcre_free(re);
-
-  if (rc > 0) {
-    return SERVER_TYPE_DRIZZLE;
-  }
-
   re = pcre_compile(DETECT_MARIADB_REGEX, 0, &error, &erroroffset, NULL);
   if (!re) {
     m_critical("Regular expression fail: %s", error);

--- a/src/server_detect.h
+++ b/src/server_detect.h
@@ -20,14 +20,12 @@
 #include <mysql.h>
 
 #define DETECT_MYSQL_REGEX "^([3-9]\\.[0-9]+\\.[0-9]+)"
-#define DETECT_DRIZZLE_REGEX "^(20[0-9]{2}\\.(0[1-9]|1[012])\\.[0-9]+)"
 #define DETECT_MARIADB_REGEX "^([0-9]{1,2}\\.[0-9]+\\.[0-9]+)"
 #define DETECT_TIDB_REGEX "TiDB"
 
 enum server_type {
   SERVER_TYPE_UNKNOWN,
   SERVER_TYPE_MYSQL,
-  SERVER_TYPE_DRIZZLE,
   SERVER_TYPE_TIDB,
   SERVER_TYPE_MARIADB,
   SERVER_TYPE_PERCONA


### PR DESCRIPTION
Unfortunately Drizzle server development has been dead for at least a decade. I'm pretty sure the support here for it no longer works, so let's remove it.

Fixes #989