### PR TITLE
Change UNIQUE_CHECKS for all MariaDB versions

### DIFF
--- a/mydumper.cnf
+++ b/mydumper.cnf
@@ -24,6 +24,6 @@ FOREIGN_KEY_CHECKS=0 /*!40114
 # sync_binlog = 0
 # innodb_flush_log_at_trx_commit = 0
 
-[myloader_session_variables_mariadb_10_6]
+[myloader_session_variables_mariadb]
 # This setting replaces the default in the section [myloader_session_variables]. More details in #987
 UNIQUE_CHECKS=1 /*!40114


### PR DESCRIPTION
The `UNIQUE_CHECKS` problem affects all versions of MariaDB 10.6 - 11.0 (so far). Given that there are only currently three supported versions lower than 10.6, a majority of users are on at least 10.6 and there is no greater-than expression in the config, we should cover all versions.