### PR TITLE
call mysql_thread_end when S-Thread and I-Thread ending

### DIFF
--- a/src/myloader_worker_index.c
+++ b/src/myloader_worker_index.c
@@ -98,6 +98,10 @@ void *worker_index_thread(struct thread_data *td) {
     cont=process_index(td);
   }
 
+  if (td->thrconn)
+    mysql_close(td->thrconn);
+  mysql_thread_end();
+  g_debug("I-Thread %d: ending", td->thread_id);
   return NULL;
 }
 

--- a/src/myloader_worker_schema.c
+++ b/src/myloader_worker_schema.c
@@ -154,6 +154,11 @@ void *worker_schema_thread(struct thread_data *td) {
     cont=process_schema(td);
   }
   g_message("S-Thread %d: Import completed", td->thread_id);
+
+  if (td->thrconn)
+    mysql_close(td->thrconn);
+  mysql_thread_end();
+  g_debug("S-Thread %d: ending", td->thread_id);
   return NULL;
 }
 


### PR DESCRIPTION
[description]
When I use myloader to load data，I got an error “**Error in my_thread_global_end(): 8 threads didn't exit**”
And I also found that only loader_thread in myloader called mysql_close() and mysql_thread_end() functions.
So maybe we should call those functions in Schema Thread and Index Thread either.
