### PR TITLE
Added option to set what fields to use on SELECT and write on INSERT

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -216,6 +216,14 @@ void load_per_table_info_from_key_file(GKeyFile *kf, struct configuration_per_ta
             value = g_key_file_get_value(kf,groups[i],keys[j],&error);
             g_hash_table_insert(conf_per_table->all_num_threads_per_table, g_strdup(groups[i]), g_strdup(value));
           }
+          if (g_strcmp0(keys[j],"columns_on_select") == 0){
+            value = g_key_file_get_value(kf,groups[i],keys[j],&error);
+            g_hash_table_insert(conf_per_table->all_columns_on_select_per_table, g_strdup(groups[i]), g_strdup(value));
+          }
+          if (g_strcmp0(keys[j],"columns_on_insert") == 0){
+            value = g_key_file_get_value(kf,groups[i],keys[j],&error);
+            g_hash_table_insert(conf_per_table->all_columns_on_insert_per_table, g_strdup(groups[i]), g_strdup(value));
+          }
         }
       }
       g_hash_table_insert(conf_per_table->all_anonymized_function,g_strdup(groups[i]),ht);

--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,8 @@ struct configuration_per_table{
   GHashTable *all_where_per_table;
   GHashTable *all_limit_per_table;
   GHashTable *all_num_threads_per_table;
+  GHashTable *all_columns_on_select_per_table;
+  GHashTable *all_columns_on_insert_per_table;
 };
 
 #define STREAM_BUFFER_SIZE 1000000

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -111,7 +111,7 @@ gchar **db_items=NULL;
 //GRecMutex *ready_database_dump_mutex = NULL;
 GRecMutex *ready_table_dump_mutex = NULL;
 
-struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL};
+struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL, NULL, NULL};
 gchar *exec_command=NULL;
 
 void initialize_start_dump(){
@@ -121,6 +121,9 @@ void initialize_start_dump(){
   conf_per_table.all_where_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
   conf_per_table.all_limit_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
   conf_per_table.all_num_threads_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
+
+  conf_per_table.all_columns_on_select_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
+  conf_per_table.all_columns_on_insert_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
 
   // until we have an unique option on lock types we need to ensure this
   if (no_locks || trx_consistency_only)

--- a/src/mydumper_start_dump.h
+++ b/src/mydumper_start_dump.h
@@ -226,6 +226,8 @@ struct db_table {
   struct function_pointer ** anonymized_function;
   gchar *where;
   gchar *limit;
+  gchar *columns_on_select;
+  gchar *columns_on_insert;
   guint num_threads;
   enum chunk_type chunk_type;
   GList *chunks;

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -1304,6 +1304,8 @@ struct db_table *new_db_table( MYSQL *conn, struct configuration *conf, struct d
   gchar * k = g_strdup_printf("`%s`.`%s`",dbt->database->name,dbt->table);
   dbt->where=g_hash_table_lookup(conf_per_table.all_where_per_table, k);
   dbt->limit=g_hash_table_lookup(conf_per_table.all_limit_per_table, k);
+  dbt->columns_on_select=g_hash_table_lookup(conf_per_table.all_columns_on_select_per_table, k);
+  dbt->columns_on_insert=g_hash_table_lookup(conf_per_table.all_columns_on_insert_per_table, k);
   dbt->num_threads=g_hash_table_lookup(conf_per_table.all_num_threads_per_table, k)?strtoul(g_hash_table_lookup(conf_per_table.all_num_threads_per_table, k), NULL, 10):num_threads;
   dbt->estimated_remaining_steps=1;
   dbt->min=NULL;

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -261,8 +261,9 @@ gboolean write_data(FILE *file, GString *data) {
 }
 
 
-void initialize_load_data_statement(GString *statement, gchar * table, const gchar *character_set, gchar *basename, MYSQL_FIELD * fields, guint num_fields){
-  g_string_append_printf(statement, "LOAD DATA LOCAL INFILE '%s%s' REPLACE INTO TABLE `%s` ", basename, exec_per_thread_extension, table);
+void initialize_load_data_statement(GString *statement, struct db_table *dbt, gchar *basename, MYSQL_FIELD * fields, guint num_fields){
+  gchar *character_set=set_names_str != NULL ? set_names_str : dbt->character_set /* "BINARY"*/;
+  g_string_append_printf(statement, "LOAD DATA LOCAL INFILE '%s%s' REPLACE INTO TABLE `%s` ", basename, exec_per_thread_extension, dbt->table);
   if (character_set && strlen(character_set)!=0)
     g_string_append_printf(statement, "CHARACTER SET %s ",character_set);
   if (fields_terminated_by_ld)
@@ -275,11 +276,16 @@ void initialize_load_data_statement(GString *statement, gchar * table, const gch
   if (lines_starting_by_ld)
     g_string_append_printf(statement, "STARTING BY '%s' ",lines_starting_by_ld);
   g_string_append_printf(statement, "TERMINATED BY '%s' (", lines_terminated_by_ld);
-  GString * set_statement=append_load_data_columns(statement,fields,num_fields);
-  g_string_append(statement,")");
-  if (set_statement != NULL){
-    g_string_append(statement,set_statement->str);
-    g_string_free(set_statement,TRUE);
+  if (dbt->columns_on_insert){
+    g_string_append(statement,dbt->columns_on_insert);
+    g_string_append(statement,")");
+  }else{
+    GString * set_statement=append_load_data_columns(statement,fields,num_fields);
+    g_string_append(statement,")");
+    if (set_statement != NULL){
+      g_string_append(statement,set_statement->str);
+      g_string_free(set_statement,TRUE);
+    }
   }
   g_string_append(statement,";\n");
 }
@@ -297,7 +303,7 @@ gboolean write_load_data_statement(struct table_job * tj, MYSQL_FIELD *fields, g
   GString *statement = g_string_sized_new(statement_size);
   char * basename=g_path_get_basename(tj->dat_filename);
   initialize_sql_statement(statement);
-  initialize_load_data_statement(statement, tj->dbt->table, set_names_str != NULL ? set_names_str : tj->dbt->character_set /* "BINARY"*/, basename, fields, num_fields);
+  initialize_load_data_statement(statement, tj->dbt, basename, fields, num_fields);
   if (!write_data(tj->sql_file, statement)) {
     g_critical("Could not write out data for %s.%s", tj->dbt->database->name, tj->dbt->table);
     return FALSE;

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -213,10 +213,16 @@ void build_insert_statement(struct db_table * dbt, MYSQL_FIELD *fields, guint nu
   g_string_append(dbt->insert_statement, dbt->table);
   g_string_append_c(dbt->insert_statement, identifier_quote_character);
 
-  if (dbt->complete_insert) {
+  if (dbt->columns_on_insert){
     g_string_append(dbt->insert_statement, " (");
-    append_columns(dbt->insert_statement,fields,num_fields);
+    g_string_append(dbt->insert_statement, dbt->columns_on_insert);
     g_string_append(dbt->insert_statement, ")");
+  }else{
+    if (dbt->complete_insert) {
+      g_string_append(dbt->insert_statement, " (");
+      append_columns(dbt->insert_statement,fields,num_fields);
+      g_string_append(dbt->insert_statement, ")");
+    }
   } 
   g_string_append(dbt->insert_statement, " VALUES");
 }
@@ -612,7 +618,7 @@ guint64 write_table_data_into_file(MYSQL *conn, struct table_job * tj){
   query = g_strdup_printf(
       "SELECT %s %s FROM `%s`.`%s` %s %s %s %s %s %s %s %s %s %s %s",
       (detected_server == SERVER_TYPE_MYSQL || detected_server == SERVER_TYPE_MARIADB) ? "/*!40001 SQL_NO_CACHE */" : "",
-      tj->dbt->select_fields->str,
+      tj->dbt->columns_on_select?tj->dbt->columns_on_select:tj->dbt->select_fields->str,
       tj->dbt->database->name, tj->dbt->table, tj->partition?tj->partition:"",
        (tj->where || where_option   || tj->dbt->where) ? "WHERE"  : "" ,      tj->where ?      tj->where : "",
        (tj->where && where_option )                    ? "AND"    : "" ,   where_option ?   where_option : "",


### PR DESCRIPTION
This an example of what you can do with this feature
```
[root@mydumper1 ~/issue_1109/mydumper]# rm -rf data ; ./mydumper -R -E -G -o data -B myd_test
[root@mydumper1 ~/issue_1109/mydumper]# cat data/myd_test.t.00000.sql
/*!40101 SET NAMES binary*/;
/*!40014 SET FOREIGN_KEY_CHECKS=0*/;
/*!40103 SET TIME_ZONE='+00:00' */;
INSERT INTO `t` VALUES(3,50)
;
[root@mydumper1 ~/issue_1109/mydumper]# cat mydumper_1109.cnf
[`myd_test`.`t`]
columns_on_select=qty,price+20
columns_on_insert=qty,price
[root@mydumper1 ~/issue_1109/mydumper]# rm -rf data ; ./mydumper -R -E -G -o data -B myd_test --defaults-extra-file=mydumper_1109.cnf
[root@mydumper1 ~/issue_1109/mydumper]# cat data/myd_test.t.00000.sql
/*!40101 SET NAMES binary*/;
/*!40014 SET FOREIGN_KEY_CHECKS=0*/;
/*!40103 SET TIME_ZONE='+00:00' */;
INSERT INTO `t` (qty,price) VALUES(3,70)
;
```