### PR TITLE
report error when lost mysql connectio

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -86,7 +86,6 @@ GOptionGroup * load_connection_entries(GOptionContext *context){
   return connection_group;
 }
 
-gboolean reconnect = 1;
 
 void configure_connection(MYSQL *conn) {
   if (connection_defaults_file != NULL)
@@ -95,7 +94,6 @@ void configure_connection(MYSQL *conn) {
     mysql_options(conn, MYSQL_READ_DEFAULT_GROUP, connection_default_file_group);
   
   mysql_options(conn, MYSQL_OPT_LOCAL_INFILE, NULL);
-  mysql_options(conn, MYSQL_OPT_RECONNECT, &reconnect);
 
   mysql_options4(conn, MYSQL_OPT_CONNECT_ATTR_ADD, "program_name", program_name);
   gchar *version=g_strdup_printf("Release %s", VERSION);


### PR DESCRIPTION
Fix a bug may cause data loss when myloader lost mysql connection
**[descriptions]**
When there was a disconnection problem during the process of restoring data, myloader may lost data without any errors detected.
**[how did this problem happened]**
When a transaction contains lots of sql, a disconnection problem will result in data loss, think about the following scenario in myloader：
1. start transaction
2. insert_sql_1
3. insert_sql_2 (lost connection and reconnect)
4. insert_sql_3 
5. commit

We have disconnection problem while execute insert_sql_2, and we reconnect successfully, now the transaction we start before has gone, insert_sql_2 and insert_sql_3 will be autocommit because of the new connection was created. But we lost  data in insert_sql_1!
During this process, myloader did not find any errors because we reconnect and re-execute insert_sql_2 success
