### PR TITLE
Wrong binlog position on ps57 after moving binlog pos extraction to threads

### DIFF
--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -944,7 +944,7 @@ void create_job_to_dump_metadata(struct configuration *conf, FILE *mdfile){
   struct job *j = g_new0(struct job, 1);
   j->job_data = (void *)mdfile;
   j->type = JOB_WRITE_MASTER_STATUS;
-  g_async_queue_push(conf->schema_queue, j);
+  g_async_queue_push(conf->initial_queue, j);
 }
 
 void create_job_to_dump_tablespaces(struct configuration *conf){

--- a/src/mydumper_jobs.h
+++ b/src/mydumper_jobs.h
@@ -21,6 +21,11 @@
 
 #ifndef _src_mydumper_jobs_h
 #define _src_mydumper_jobs_h
+struct schema_metadata_job {
+  FILE *metadata_file;
+  GMutex *release_binlog_mutex;
+};
+
 struct schema_job {
   struct db_table *dbt;
   char *filename;

--- a/src/mydumper_start_dump.h
+++ b/src/mydumper_start_dump.h
@@ -65,6 +65,7 @@ struct configuration {
   GAsyncQueue *ready;
   GAsyncQueue *ready_non_innodb_queue;
   GAsyncQueue *db_ready;
+  GAsyncQueue *binlog_ready;
   GAsyncQueue *unlock_tables;
   GAsyncQueue *pause_resume;
   GAsyncQueue *gtid_pos_checked;

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -704,6 +704,11 @@ gboolean process_job_builder_job(struct thread_data *td, struct job *job){
 //    case JOB_TABLE:
 //      thd_JOB_TABLE(td, job);
 //      break;
+    case JOB_WRITE_MASTER_STATUS:
+      write_snapshot_info(td->thrconn, job->job_data);
+      g_async_queue_push(td->conf->binlog_ready,GINT_TO_POINTER(1));
+      g_free(job);
+      break;
     case JOB_SHUTDOWN:
       g_free(job);
       return FALSE;
@@ -755,6 +760,7 @@ gboolean process_job(struct thread_data *td, struct job *job){
       break;
     case JOB_WRITE_MASTER_STATUS:
       write_snapshot_info(td->thrconn, job->job_data);
+      g_async_queue_push(td->conf->binlog_ready,GINT_TO_POINTER(1));
       g_free(job);
       break;
     case JOB_SHUTDOWN:


### PR DESCRIPTION
this bug was introduced in #847 

the problem was caused when binlog lock was released before writing the data to disk. 
Now, we move to a previous queue and check that has been writing before unlock the binary log.
