### PR TITLE
Removing unused max_rows variables

### DIFF
--- a/src/mydumper_arguments.c
+++ b/src/mydumper_arguments.c
@@ -147,8 +147,6 @@ static GOptionEntry daemon_entries[] = {
 
 
 static GOptionEntry chunks_entries[] = {
-    {"max-rows", 0, 0, G_OPTION_ARG_INT64, &max_rows,
-     "Limit the number of rows per block after the table is estimated, default 1000000. It has been deprecated, use --rows instead. Removed in future releases", NULL},
     {"char-deep", 0, 0, G_OPTION_ARG_INT64, &char_deep,
      "Defines the amount of characters to use when the primary key is a string",NULL},
     {"char-chunk", 0, 0, G_OPTION_ARG_INT64, &char_chunk,

--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -37,7 +37,6 @@
 #include "regex.h"
 gboolean split_partitions = FALSE;
 gchar *partition_regex = FALSE;
-guint64 max_rows=1000000;
 GAsyncQueue *give_me_another_innodb_chunk_step_queue;
 GAsyncQueue *give_me_another_non_innodb_chunk_step_queue;
 guint char_chunk=0;

--- a/src/mydumper_global.h
+++ b/src/mydumper_global.h
@@ -31,7 +31,6 @@ extern gboolean views_as_tables;
 extern gboolean dump_checksums;
 extern gboolean split_partitions;
 extern guint char_deep;
-extern guint64 max_rows;
 extern const gchar *exec_per_thread_extension;
 extern gchar *exec_per_thread;
 extern gboolean order_by_primary_key;


### PR DESCRIPTION
This was replaced by --rows new accepted values