### PR TITLE
Using semaphores to prevent excessive local file accumulation during output throttling.

### DIFF
--- a/src/mydumper_start_dump.h
+++ b/src/mydumper_start_dump.h
@@ -272,6 +272,7 @@ struct db_table {
 struct stream_queue_element{
   struct db_table *dbt;
   gchar *filename;
+  GAsyncQueue *done;
 };
 
 struct schema_post {


### PR DESCRIPTION
Make sure the stream output thread begins reading the file before the worker thread advances to the next step. This prevents excessive local file accumulation, which could occupy excessive disk space in scenarios where the output byte stream is blocked or consumed at a slow rate.