### PR TITLE
fix function: is_table_in_list 

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -481,11 +481,16 @@ gboolean m_remove(gchar * directory, const gchar * filename){
   return TRUE;
 }
 
-gboolean is_table_in_list(gchar *table_name, gchar **tl){
+gboolean is_table_in_list(gchar *database, gchar *table, gchar **tl){
+  gchar * table_name=g_strdup_printf("%s.%s", database, table);
   guint i = 0;
-  for (i = 0; tl[i] != NULL; i++)
-    if (g_ascii_strcasecmp(tl[i], table_name) == 0)
+  for (i = 0; tl[i] != NULL; i++) {
+    if (g_ascii_strcasecmp(tl[i], table_name) == 0){
+      g_free(table_name);
       return TRUE;
+    }
+  }
+  g_free(table_name);
   return FALSE;
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -78,7 +78,7 @@ void load_hash_from_key_file(GKeyFile *kf, GHashTable * set_session_hash, const 
 void load_per_table_info_from_key_file(GKeyFile *kf, struct configuration_per_table * conf_per_table, struct function_pointer * init_function_pointer());
 void refresh_set_session_from_hash(GString *ss, GHashTable * set_session_hash);
 void refresh_set_global_from_hash(GString *ss, GString *sr, GHashTable * set_global_hash);
-gboolean is_table_in_list(gchar *table_name, gchar **tl);
+gboolean is_table_in_list(gchar *database, gchar *table, gchar **tl);
 GHashTable * initialize_hash_of_session_variables();
 void load_common_entries(GOptionGroup *main_group);
 void free_hash(GHashTable * set_session_hash);

--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -1735,16 +1735,7 @@ void dump_database_thread(MYSQL *conn, struct configuration *conf, struct databa
 
     /* In case of table-list option is enabled, check if table is part of the
      * list */
-    if (tables) {
-/*      int table_found = 0;
-      for (i = 0; tables[i] != NULL; i++)
-        if (g_ascii_strcasecmp(tables[i], row[0]) == 0)
-          table_found = 1;
-*/
-      if (!is_table_in_list(row[0], tables))
-        dump = 0;
-    }
-    if (!dump)
+    if (tables && !is_table_in_list(database->name, row[0], tables))
       continue;
 
     /* Special tables */

--- a/src/myloader_common.c
+++ b/src/myloader_common.c
@@ -173,7 +173,7 @@ gboolean eval_table( char *db_name, char * table_name, GMutex * mutex){
     g_error("Table name is null on eval_table()");
   g_mutex_lock(mutex);
   if ( tables ){
-    if ( ! is_table_in_list(table_name, tables) ){
+    if (!is_table_in_list( db_name, table_name, tables)){
       g_mutex_unlock(mutex);
       return FALSE;
     }


### PR DESCRIPTION
The input table_names for is_table_in_list do not include the dbname, thus making it unable to match any table.

For example:
`myloader -T` does not work.
`mydumper -T db1.table1 -B db1` will dump all tables in db1.
Warning: In the current version, `mydumper -T db1.table1 -B db1` only dump db1.table1. This is different from the previous version which would dump all tables.

I'm not very familiar with all code, maybe you need to do more verification.