### PR TITLE
myloader wrong behavior without config file

### DIFF
--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -548,7 +548,6 @@ void initialize_sql_statement(GString *statement){
   if (is_mysql_like())  {
     if (set_names_statement)
       g_string_printf(statement,"%s;\n",set_names_statement);
-    g_string_append(statement, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\n");
     if (!skip_tz) {
       g_string_append(statement, "/*!40103 SET TIME_ZONE='+00:00' */;\n");
     }
@@ -556,8 +555,6 @@ void initialize_sql_statement(GString *statement){
     if (!skip_tz) {
       g_string_printf(statement, "/*!40103 SET TIME_ZONE='+00:00' */;\n");
     }
-  } else {
-    g_string_printf(statement, "SET FOREIGN_KEY_CHECKS=0;\n");
   }
 }
 

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -112,6 +112,21 @@ GHashTable * myloader_initialize_hash_of_session_variables(){
   if (commit_count > 1)
     g_hash_table_insert(set_session_hash,g_strdup("AUTOCOMMIT"),g_strdup("0"));
 
+  const int m= get_major();
+  const int s= get_secondary();
+  const int r= get_revision();
+
+  if (m >= 4) {
+    if (m > 4 || s > 0 || r >= 14) {
+      g_hash_table_insert(set_session_hash,g_strdup("UNIQUE_CHECKS"), g_strdup("0"));
+      g_hash_table_insert(set_session_hash,g_strdup("FOREIGN_KEY_CHECKS"), g_strdup("0"));
+    }
+    if (m > 4 || s > 1 || (s == 1 && r >= 1))
+      g_hash_table_insert(set_session_hash,g_strdup("SQL_MODE"), g_strdup("'NO_AUTO_VALUE_ON_ZERO'"));
+    if (m > 4 || s > 1 || (s == 1 && r >= 11))
+      g_hash_table_insert(set_session_hash,g_strdup("SQL_NOTES"), g_strdup("0"));
+  }
+
   return set_session_hash;
 }
 


### PR DESCRIPTION
Without config file session variables are not set, but some of them are required for correct restoration (NO_AUTO_VALUE_ON_ZERO and FOREIGN_KEY_CHECKS). The patch sets some reasonable values for myloader session variables, so it could work without configuration file.

Bug description:

https://jira.mariadb.org/browse/CONTRIB-19

The reason for this patch:

Configuration file should not be mandatory for correct work of software. This is user unfriendly! Otherwise you should fail it to run if it doesn't find configuration file. For constant machine-independent data there is /usr/share directory according to FHS, it is wrong to place it into /etc (though it is very correct to have any vars in /etc **above** the default values).