### PR TITLE
Wrong dump or failed restore in some SQL modes

### DIFF
--- a/src/common_options.c
+++ b/src/common_options.c
@@ -41,6 +41,7 @@ int detected_server = 0;
 GString *set_session = NULL;
 GString *set_global = NULL;
 GString *set_global_back = NULL;
+gchar *sql_mode= NULL;
 MYSQL *main_connection = NULL;
 gboolean no_schemas = FALSE;
 gboolean no_data = FALSE;

--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -549,6 +549,8 @@ void initialize_sql_statement(GString *statement){
     if (set_names_statement)
       g_string_printf(statement,"%s;\n",set_names_statement);
     g_string_append(statement, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\n");
+    if (sql_mode)
+      g_string_printf(statement, "/*!40101 SET SQL_MODE=%s*/;\n", sql_mode);
     if (!skip_tz) {
       g_string_append(statement, "/*!40103 SET TIME_ZONE='+00:00' */;\n");
     }
@@ -558,6 +560,8 @@ void initialize_sql_statement(GString *statement){
     }
   } else {
     g_string_printf(statement, "SET FOREIGN_KEY_CHECKS=0;\n");
+    if (sql_mode)
+      g_string_printf(statement, "SET SQL_MODE=%s;\n", sql_mode);
   }
 }
 

--- a/src/mydumper_global.h
+++ b/src/mydumper_global.h
@@ -105,6 +105,7 @@ extern GRecMutex *ready_table_dump_mutex;
 extern GString *set_global;
 extern GString *set_global_back;
 extern GString *set_session;
+extern gchar *sql_mode;
 extern guint char_chunk;
 extern guint complete_insert;
 extern guint dump_number;

--- a/src/mydumper_jobs.c
+++ b/src/mydumper_jobs.c
@@ -147,6 +147,7 @@ void write_schema_definition_into_file(MYSQL *conn, struct database *database, c
   }
 
   GString *statement = g_string_sized_new(statement_size);
+  initialize_sql_statement(statement);
 
   query = g_strdup_printf("SHOW CREATE DATABASE IF NOT EXISTS `%s`", database->name);
   if (mysql_query(conn, query) || !(result = mysql_use_result(conn))) {


### PR DESCRIPTION
There are dangerous SQL modes (NO_BACKSLASH_ESCAPES, PIPES_AS_CONCAT) in which mydumper cannot operate correctly (maybe it can operate in PIPES_AS_CONCAT now, but it may break in future if mydumper will utilize || operator). OTOH there are SQL modes that must be same when dumping and restoring (like ORACLE mode, ANSI, ANSI_QUOTES).

The patch cuts out NO_BACKSLASH_ESCAPES and PIPES_AS_CONCAT and sets the rest as its session sql_mode. It also dumps this sql_mode to files.

Bugs descriptions:

https://jira.mariadb.org/browse/CONTRIB-26
https://jira.mariadb.org/browse/CONTRIB-27
https://jira.mariadb.org/browse/CONTRIB-28