### PR TITLE
Double quote in schema dump fixes

### DIFF
--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -550,12 +550,13 @@ void determine_explain_columns(MYSQL_RES *result, guint *rowscol){
 
 
 void initialize_sql_statement(GString *statement){
-  if (is_mysql_like())  {
+  g_string_set_size(statement, 0);
+  if (is_mysql_like()) {
     if (set_names_statement)
       g_string_printf(statement,"%s;\n",set_names_statement);
     g_string_append(statement, "/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\n");
     if (sql_mode)
-      g_string_printf(statement, "/*!40101 SET SQL_MODE=%s*/;\n", sql_mode);
+      g_string_append_printf(statement, "/*!40101 SET SQL_MODE=%s*/;\n", sql_mode);
     if (!skip_tz) {
       g_string_append(statement, "/*!40103 SET TIME_ZONE='+00:00' */;\n");
     }
@@ -566,7 +567,7 @@ void initialize_sql_statement(GString *statement){
   } else {
     g_string_printf(statement, "SET FOREIGN_KEY_CHECKS=0;\n");
     if (sql_mode)
-      g_string_printf(statement, "SET SQL_MODE=%s;\n", sql_mode);
+      g_string_append_printf(statement, "SET SQL_MODE=%s;\n", sql_mode);
   }
 }
 

--- a/src/myloader.h
+++ b/src/myloader.h
@@ -206,5 +206,6 @@ const char *ft2str(enum file_type ft)
     return "INTERMEDIATE_ENDED";
   }
   g_assert(0);
+  return NULL;
 }
 #endif

--- a/src/myloader_control_job.h
+++ b/src/myloader_control_job.h
@@ -32,6 +32,7 @@ static inline const char *jtype2str(enum control_job_type jtype)
     return "JOB_SHUTDOWN";
   }
   g_assert(0);
+  return NULL;
 }
 
 union control_job_data {


### PR DESCRIPTION
For ANSI/ANSI_QUOTES/ORACLE we use double quote as identifier quote character. Dumping views/routines/sequences didn't handle that properly.

SHOW CREATE can work with backticks in any mode. But this is rather a kludge than well-defined behaviour, so this should be avoided.

Bug description:

https://jira.mariadb.org/browse/CONTRIB-34