### PR TITLE
myloader ignores --max-threads-per-table

### DIFF
--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -289,7 +289,7 @@ void set_chunk_strategy_for_dbt(MYSQL *conn, struct db_table *dbt){
       csi->chunk_functions.get_next = &get_next_partition_chunk;
       csi->chunk_step=new_real_partition_step(partitions,0,0);
     }else{
-      if (dbt->starting_chunk_step_size>0 && dbt->rows_in_sts > dbt->min_chunk_step_size ){
+      if (dbt->starting_chunk_step_size > 0) {
         csi = initialize_chunk_step_item(conn, dbt, 0, NULL, rows);
       }else{
         csi = new_none_chunk_step();


### PR DESCRIPTION
Fix 96e1d8dd in set_chunk_strategy_for_dbt() missed redundant and not working condition.

Bug description:

https://jira.mariadb.org/browse/CONTRIB-36