### PR TITLE
Removing O_DSYNC when opening files

### DIFF
--- a/src/mydumper_common.c
+++ b/src/mydumper_common.c
@@ -200,7 +200,7 @@ int m_open_pipe(gchar **filename, const char *type){
   f=g_new0(struct fifo, 1);
   f->out_mutex=g_mutex_new();
   g_mutex_lock(f->out_mutex);
-  f->fdout = open(new_filename, O_CREAT|O_WRONLY|O_TRUNC|O_DSYNC, 0660);
+  f->fdout = open(new_filename, O_CREAT|O_WRONLY|O_TRUNC, 0660);
   if (!f->fdout){
     g_error("opening file: %s", new_filename);
   }

--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -95,7 +95,7 @@ void *process_stream(void *data){
     free(used_filemame);
     if (no_stream == FALSE){
 //      g_message("Stream Opening: %s",sf->filename);
-      f=open(sf->filename,O_RDONLY|O_DSYNC);
+      f=open(sf->filename,O_RDONLY);
       if (f < 0){
         m_error("File failed to open: %s (%s)", sf->filename, strerror(errno));
       }else{


### PR DESCRIPTION
O_DSYNC caused performance issues when compression is being used.