### PR TITLE
Checking improvements

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -31,6 +31,7 @@
 
 GAsyncQueue *stream_queue = NULL;
 gboolean skip_defer= FALSE;
+gboolean check_row_count= FALSE;
 
 /*
 const char *usr_bin_zstd_cmd[] = {"/usr/bin/zstd", "-c", NULL};

--- a/src/mydumper_arguments.c
+++ b/src/mydumper_arguments.c
@@ -87,6 +87,8 @@ static GOptionEntry extra_entries[] = {
      "Compress output files using: /usr/bin/gzip and /usr/bin/zstd. Options: GZIP and ZSTD. Default: GZIP", NULL},
     {"skip-defer", 0, 0, G_OPTION_ARG_NONE, &skip_defer,
      "Do not defer integer sharding until all non-integer PK tables processed (saves RSS for huge quantities of tables)", NULL},
+    {"check-row-count", 0, 0, G_OPTION_ARG_NONE, &check_row_count,
+     "Run SELECT COUNT(*) and fail mydumper if dumped row count is different", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 static GOptionEntry lock_entries[] = {

--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -99,7 +99,6 @@ struct chunk_step_item * new_none_chunk_step(){
 struct chunk_step_item * initialize_chunk_step_item (MYSQL *conn, struct db_table *dbt, guint position, GString *prefix, guint64 rows) {
     struct chunk_step_item * csi=NULL;
 
-//  if (dbt->starting_chunk_step_size>0 && dbt->rows_in_sts > dbt->min_chunk_step_size ){
     gchar *field=g_list_nth_data(dbt->primary_key, position);
     gchar *query = NULL;
     MYSQL_ROW row;
@@ -276,7 +275,8 @@ void set_chunk_strategy_for_dbt(MYSQL *conn, struct db_table *dbt){
   g_mutex_lock(dbt->chunks_mutex);
   struct chunk_step_item * csi = NULL;
 
-  guint64 rows = get_rows_from_explain(conn, dbt, NULL ,NULL);
+  const guint64 rows= get_rows_from_explain(conn, dbt, NULL ,NULL);
+  dbt->rows_total= rows;
   if (rows > dbt->min_chunk_step_size){
     GList *partitions=NULL;
     if (split_partitions || dbt->partition_regex){

--- a/src/mydumper_global.h
+++ b/src/mydumper_global.h
@@ -77,6 +77,7 @@ extern gboolean use_savepoints;
 extern gboolean clear_dumpdir;
 extern gboolean dirty_dumpdir;
 extern gboolean skip_defer;
+extern gboolean check_row_count;
 extern gchar *db;
 extern gchar *disk_limits;
 extern gchar *dump_directory;

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -757,6 +757,10 @@ void print_dbt_on_metadata(FILE *mdfile, struct db_table *dbt){
   GString *data = g_string_sized_new(100);
   print_dbt_on_metadata_gstring(dbt, data);
   fprintf(mdfile, "%s", data->str);
+  if (check_row_count && (dbt->rows != dbt->rows_total)) {
+    m_critical("Row count mismatch found for %s.%s: got %u of %u expected",
+               dbt->database->name, dbt->table, dbt->rows, dbt->rows_total);
+  }
 }
 
 

--- a/src/mydumper_start_dump.h
+++ b/src/mydumper_start_dump.h
@@ -281,7 +281,6 @@ struct db_table {
   char *min;
   char *max;
 //  char *field;
-  guint64 rows_in_sts;
   GString *select_fields;
   gboolean complete_insert;
   GString *insert_statement;
@@ -289,6 +288,7 @@ struct db_table {
   gboolean is_sequence;
   gboolean has_json_fields;
   char *character_set;
+  guint64 rows_total;
   guint64 rows;
   guint64 estimated_remaining_steps;
   GMutex *rows_lock;

--- a/src/mydumper_working_thread.h
+++ b/src/mydumper_working_thread.h
@@ -31,7 +31,7 @@ void *working_thread(struct thread_data *td);
 void dump_table(MYSQL *conn, struct db_table *dbt, struct configuration *conf, gboolean is_innodb);
 void new_table_to_dump(MYSQL *conn, struct configuration *conf, gboolean is_view,
                        gboolean is_sequence, struct database * database, char *table,
-                       char *collation, gchar *ecol, guint64 rows_in_st);
+                       char *collation, gchar *ecol);
 void initialize_working_thread();
 void finalize_working_thread();
 void free_db_table(struct db_table * dbt);

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -76,6 +76,7 @@ gboolean innodb_optimize_keys_all_tables = FALSE;
 
 gboolean enable_binlog = FALSE;
 gboolean disable_redo_log = FALSE;
+enum checksum_modes checksum_mode= CHECKSUM_FAIL;
 gboolean skip_triggers = FALSE;
 gboolean skip_post = FALSE;
 gboolean serial_tbl_creation = FALSE;
@@ -476,17 +477,22 @@ int main(int argc, char *argv[]) {
   }
 
 
-  GHashTableIter iter;
-  gchar * lkey;
-  g_hash_table_iter_init ( &iter, db_hash);
-  struct database *d=NULL;
-  while ( g_hash_table_iter_next ( &iter, (gpointer *) &lkey, (gpointer *) &d ) ) {
-    if (d->schema_checksum != NULL && !no_schemas)
-      checksum_database_template(d->real_database, d->schema_checksum,  conn, "Schema create checksum", checksum_database_defaults);
-    if (d->post_checksum != NULL && !skip_post)
-      checksum_database_template(d->real_database, d->post_checksum,  conn, "Post checksum", checksum_process_structure);
-    if (d->triggers_checksum != NULL && !skip_triggers)
-      checksum_database_template(d->real_database, d->triggers_checksum,  conn, "Triggers checksum", checksum_trigger_structure_from_database);
+  if (checksum_mode != CHECKSUM_SKIP) {
+    GHashTableIter iter;
+    gchar *lkey;
+    g_hash_table_iter_init(&iter, db_hash);
+    struct database *d= NULL;
+    while (g_hash_table_iter_next(&iter, (gpointer *) &lkey, (gpointer *) &d)) {
+      if (d->schema_checksum != NULL && !no_schemas)
+        checksum_database_template(d->real_database, d->schema_checksum,  conn,
+                                  "Schema create checksum", checksum_database_defaults);
+      if (d->post_checksum != NULL && !skip_post)
+        checksum_database_template(d->real_database, d->post_checksum,  conn,
+                                  "Post checksum", checksum_process_structure);
+      if (d->triggers_checksum != NULL && !skip_triggers)
+        checksum_database_template(d->real_database, d->triggers_checksum,  conn,
+                                  "Triggers checksum", checksum_trigger_structure_from_database);
+    }
   }
 
 

--- a/src/myloader_common.c
+++ b/src/myloader_common.c
@@ -420,42 +420,74 @@ void refresh_table_list(struct configuration *conf){
   g_mutex_unlock(conf->table_hash_mutex);
 }
 
-void checksum_dbt_template(struct db_table *dbt, gchar *dbt_checksum,  MYSQL *conn, const gchar *message, gchar* fun()) {
-  int errn=0;
-  gchar *checksum=fun(conn, dbt->database->real_database, dbt->real_table, &errn);
-  if (g_strcmp0(dbt_checksum,checksum)){
-    g_warning("%s mismatch found for `%s`.`%s`. Got '%s', expecting '%s'", message,dbt->database->real_database, dbt->real_table, checksum, dbt_checksum);
-  }else{
-    g_message("%s confirmed for `%s`.`%s`", message, dbt->database->real_database, dbt->real_table);
+static inline void
+checksum_template(const char *dbt_checksum, const char *checksum, const char *err_templ,
+                  const char *info_templ, const char *message, const char *_db, const char *_table)
+{
+  g_assert(checksum_mode != CHECKSUM_SKIP);
+  if (g_strcmp0(dbt_checksum, checksum)) {
+    if (_table) {
+      if (checksum_mode == CHECKSUM_WARN)
+        g_warning(err_templ, message, _db, _table, checksum, dbt_checksum);
+      else
+        g_critical(err_templ, message, _db, _table, checksum, dbt_checksum);
+    } else {
+      if (checksum_mode == CHECKSUM_WARN)
+        g_warning(err_templ, message, _db, checksum, dbt_checksum);
+      else
+        g_critical(err_templ, message, _db, checksum, dbt_checksum);
+    }
+  } else {
+    g_message(info_templ, message, _db, _table);
   }
 }
 
-void checksum_database_template(gchar *database, gchar *dbt_checksum,  MYSQL *conn, const gchar *message, gchar* fun()) {
-  int errn=0;
-  gchar *checksum=fun(conn, database, NULL, &errn);
-  if (g_strcmp0(dbt_checksum,checksum)){
-    g_warning("%s mismatch found for `%s`. Got '%s', expecting '%s'", message, database, checksum, dbt_checksum);
-  }else{
-    g_message("%s confirmed for `%s`", message, database);
-  }
+void checksum_dbt_template(struct db_table *dbt, gchar *dbt_checksum,  MYSQL *conn,
+                           const gchar *message, gchar* fun())
+{
+  int errn= 0;
+  const char *_db= dbt->database->real_database;
+  const char *_table= dbt->real_table;
+  const char *checksum= fun(conn, _db, _table, &errn);
+  checksum_template(dbt_checksum, checksum,
+                    "%s mismatch found for %s.%s: got %s, expecting %s",
+                    "%s confirmed for %s.%s", message, _db, _table);
 }
 
-void checksum_dbt(struct db_table *dbt,  MYSQL *conn) {
+void checksum_database_template(gchar *_db, gchar *dbt_checksum,  MYSQL *conn,
+                                const gchar *message, gchar* fun())
+{
+  int errn= 0;
+  const char *checksum= fun(conn, _db, NULL, &errn);
+  checksum_template(dbt_checksum, checksum,
+                    "%s mismatch found for %s: got %s, expecting %s",
+                    "%s confirmed for %s", message, _db, NULL);
+}
+
+void checksum_dbt(struct db_table *dbt,  MYSQL *conn)
+{
+  if (checksum_mode == CHECKSUM_SKIP)
+    return;
   if (!no_schemas){
     if (dbt->schema_checksum!=NULL){
       if (dbt->is_view)
-        checksum_dbt_template(dbt, dbt->schema_checksum, conn, "View checksum", checksum_view_structure);
+        checksum_dbt_template(dbt, dbt->schema_checksum, conn,
+                              "View checksum", checksum_view_structure);
       else
-        checksum_dbt_template(dbt, dbt->schema_checksum, conn, "Structure checksum", checksum_table_structure);
+        checksum_dbt_template(dbt, dbt->schema_checksum, conn,
+                              "Structure checksum", checksum_table_structure);
     }
     if (dbt->indexes_checksum!=NULL)
-      checksum_dbt_template(dbt, dbt->indexes_checksum, conn, "Schema index checksum", checksum_table_indexes);
+      checksum_dbt_template(dbt, dbt->indexes_checksum, conn,
+                            "Schema index checksum", checksum_table_indexes);
   }
   if (dbt->triggers_checksum!=NULL && !skip_triggers)
-    checksum_dbt_template(dbt, dbt->triggers_checksum, conn, "Trigger checksum", checksum_trigger_structure);
+    checksum_dbt_template(dbt, dbt->triggers_checksum, conn,
+                          "Trigger checksum", checksum_trigger_structure);
 
   if (dbt->data_checksum!=NULL && !no_data)
-    checksum_dbt_template(dbt, dbt->data_checksum, conn, "Data checksum", checksum_table);
+    checksum_dbt_template(dbt, dbt->data_checksum, conn,
+                          "Data checksum", checksum_table);
 
 }
 

--- a/src/myloader_common.h
+++ b/src/myloader_common.h
@@ -50,7 +50,8 @@ gboolean has_exec_per_thread_extension(const gchar *filename);
 gchar *build_dbt_key(gchar *a, gchar *b);
 gboolean m_query(  MYSQL *conn, const gchar *query, void log_fun(const char *, ...) , const char *fmt, ...);
 void checksum_dbt(struct db_table *dbt,  MYSQL *conn) ;
-void checksum_database_template(gchar *database, gchar *dbt_checksum,  MYSQL *conn, const gchar *message, gchar* fun()) ;
+void checksum_database_template(gchar *_db, gchar *dbt_checksum,  MYSQL *conn,
+                                const gchar *message, gchar* fun());
 gchar *get_value(GKeyFile * kf,gchar *group, const gchar *key);
 void change_master(GKeyFile * kf,gchar *group, GString *s);
 gboolean get_command_and_basename(gchar *filename, gchar ***command, gchar **basename);

--- a/src/myloader_global.h
+++ b/src/myloader_global.h
@@ -35,7 +35,14 @@ extern gboolean program_version;
 extern guint verbose;
 extern gboolean debug;
 
+enum checksum_modes {
+  CHECKSUM_SKIP= 0,
+  CHECKSUM_WARN,
+  CHECKSUM_FAIL
+};
+
 extern gboolean disable_redo_log;
+extern enum checksum_modes checksum_mode;
 extern gchar *purge_mode_str;
 extern GString *set_global;
 extern GString *set_global_back;


### PR DESCRIPTION
New options:

myloader --checksum [fail|warn|skip]: control how to treat checksums in dump (made with --checksum-all)

- Default is "fail" which means stop myloader on first checksum
mismatch;

- "warn" works like before: print warning;

- "skip" makes myloader as quick as without checksums, i.e. it skips
checksums calculation;

mydumper --check-row-count: Rows count check when making dump

When enabled, row count is done by SELECT COUNT(*)
which is slower than EXPLAIN SELECT but accurate. If dumped row count is different mydumper fails with error message.
