### PR TITLE
Adding reconnection on mydumper

### DIFF
--- a/src/mydumper_working_thread.c
+++ b/src/mydumper_working_thread.c
@@ -537,6 +537,8 @@ void initialize_consistent_snapshot(struct thread_data *td){
   if (g_strcmp0(td->binlog_snapshot_gtid_executed,"")==0){
     if (no_locks){
       g_warning("We are not able to determine if the backup will be consistent.");
+    }else{
+      it_is_a_consistent_backup=TRUE;
     }
   }else{
     if (cont){

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -673,8 +673,8 @@ void write_table_job_into_file(MYSQL *conn, struct table_job * tj){
     write_row_into_file_in_sql_mode(conn, result, tj);
 
   if (mysql_errno(conn)) {
-    g_critical("Could not read data from %s.%s: %s", tj->dbt->database->name, tj->dbt->table,
-               mysql_error(conn));
+    g_critical("Could not read data from %s.%s: %s\nQuery: %s", tj->dbt->database->name, tj->dbt->table,
+               mysql_error(conn), query);
     errors++;
   }
 

--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -690,9 +690,11 @@ void write_table_job_into_file(MYSQL *conn, struct table_job * tj){
                mysql_error(conn));
     errors++;
     if (mysql_ping(tj->td->thrconn)) {
-      g_warning("Thread %d: Reconnecting due errors", tj->td->thread_id);
-      m_connect(tj->td->thrconn);
-      execute_gstring(tj->td->thrconn, set_session);
+      if (!it_is_a_consistent_backup){
+        g_warning("Thread %d: Reconnecting due errors", tj->td->thread_id);
+        m_connect(tj->td->thrconn);
+        execute_gstring(tj->td->thrconn, set_session);
+      }
     } 
  }
 


### PR DESCRIPTION
I created a table with 5M rows without secondary indexes:
```
sysbench /usr/share/sysbench/oltp_write_only.lua --table-size=5000000 --tables=1 --threads=1 --mysql-user=root --mysql-db=sbtest --rate=10 --time=0 --report-interval=10 --create_secondary=off prepare
```
to kill just one thread, I created this:
```
echo "select concat('Kill ',ID) from information_schema.PROCESSLIST where INFO like 'SELECT %sbtest%' and ID != connection_id() limit 1" | mysql -N | mysql
```
The mydumper command was tested with GTID ON and OFF and this 2 combinations:
```
rm -rf data/; ./mydumper -B sbtest -o data -v 3 -M -r 1000000 -t 2 -F 20 --no-locks
rm -rf data/; ./mydumper -B sbtest -o data -v 3 -M -r 1000000 -t 2 -F 20 
```
There are multiples combinations and considerations, the most important is that reconnection is not possible during what mydumper considers CONSISTENT backup. For instance, if you use --no-locks on a stopped replica, over MySQL, mydumper will consider it is inconsistent, even if the database is not receiving traffic, but if you do the same on Percona with GTID ON, it will be a consistent backup. 