### PR TITLE
Disabling split by varchar

### DIFF
--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -217,11 +217,9 @@ struct chunk_step_item * initialize_chunk_step_item (MYSQL *conn, struct db_tabl
       case MYSQL_TYPE_STRING:
       case MYSQL_TYPE_VAR_STRING:
 
-/*
         if (minmax)
           mysql_free_result(minmax);
         return new_none_chunk_step();
-*/
 
         csi=new_char_step_item(conn, TRUE, prefix, dbt->primary_key->data, 0, 0, row, lengths, NULL);
         if (minmax)


### PR DESCRIPTION
I decided that we are going to disable the chunks by varchars.
It was not implemented correctly. 
It was a good exercise, but it is not mature enough. 

We need to develop a better understanding of the use cases where it will be useful. For instance, when binary is used or when UTF8MB4, and what is the best approach to split the chunks.  