### PR TITLE
When connecting to MySQL, if client group exists in the x.cnf, ignore others

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -622,7 +622,8 @@ void initialize_common_options(GOptionContext *context, const gchar *group){
     if (g_key_file_has_group(key_file, group )){
       parse_key_file_group(key_file, context, group);
       set_connection_defaults_file_and_group(defaults_file, group); 
-    }else if (g_key_file_has_group(key_file, "client" )){
+    }
+    if (g_key_file_has_group(key_file, "client" )){
       set_connection_defaults_file_and_group(defaults_file, NULL);
     }
   }else
@@ -644,7 +645,8 @@ void initialize_common_options(GOptionContext *context, const gchar *group){
       g_message("Parsing extra key file");
       parse_key_file_group(extra_key_file, context, group);
       set_connection_defaults_file_and_group(defaults_extra_file, group);
-    } else if (g_key_file_has_group(extra_key_file, "client" )){
+    } 
+    if (g_key_file_has_group(extra_key_file, "client" )){
       set_connection_defaults_file_and_group(defaults_extra_file, NULL);
     }
   }else


### PR DESCRIPTION
When both the "mydumper" and "client" groups exist in the mydumper.cnf file, only the "client" group should be used to connect to MySQL. This is because these two groups have some parameters that are not shared, such as "database".
Eg：
```
[client]
host=127.0.0.1
user=root
port=3307
password=123

[mydumper]
database=db1,db2
```
