### PR TITLE
fix split partitions

### DIFF
--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -312,9 +312,9 @@ void set_chunk_strategy_for_dbt(MYSQL *conn, struct db_table *dbt){
 //      csi->chunk_functions.process = &process_partition_chunk;
 //      csi->chunk_functions.get_next = &get_next_partition_chunk;
 //      csi->chunk_step=new_real_partition_step(partitions,0,0);
-
+    }
+    if (partitions){
       csi=new_real_partition_step_item(partitions,0,0);
-
     }else{
       if (dbt->starting_chunk_step_size > 0) {
         csi = initialize_chunk_step_item(conn, dbt, 0, NULL, rows);


### PR DESCRIPTION
when run mydumper with --split-partitions , tables without partition will be skip;




