### PR TITLE
docs: minor typo in docs causing doc build failure

### DIFF
--- a/docs/_build/conf.py.in
+++ b/docs/_build/conf.py.in
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/html/static']
+#html_static_path = ['@CMAKE_CURRENT_SOURCE_DIR@/html/static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -7,4 +7,4 @@ The code for mydumper has been written by the following people:
   * `Andrew Hutchings <http://www.linuxjedi.co.uk>`_, MariaDB Foundation ( andrew at mariadb dot org )
   * `Mark Leith <http://www.markleith.co.uk/>`_, Oracle Corporation ( mark dot leith at oracle dot com )
   * `Max Bubenick <http://www.bube.com.ar>`_, Percona RDBA ( max dot bubenick at percona dot com )
-  * `David Ducos, Percona Professional Services ( david dot ducos at percona dot com )
+  * David Ducos, Percona Professional Services, ( david dot ducos at percona dot com )

--- a/docs/files.rst
+++ b/docs/files.rst
@@ -74,12 +74,13 @@ by default is going to use GZIP compression method. You can also use ZSTD to com
 The internal compression mechanisim has been removed from the code and we are using /usr/bin/gzip and 
 /usr/bin/zstd. If you need to change to a different location or different compression software, you
 need to set::
+
   --exec-per-thread
   --exec-per-thread-extension
 
 Binary Logs
 -----------
-Binary logs are retrieved when :option:`--binlogs <mydumper --binlogs>` option
+Binary logs are retrieved when :option:`--enable-binlog <myloader --enable-binlog>` option
 has been set.  This will store them in the ``binlog_snapshot/`` sub-directory
 inside the dump directory.
 


### PR DESCRIPTION
Minor syntax errors causing doc generation warnings