### PR TITLE
Adding --skip-ddl-lock

### DIFF
--- a/src/mydumper_arguments.c
+++ b/src/mydumper_arguments.c
@@ -111,6 +111,7 @@ static GOptionEntry lock_entries[] = {
      "Minimize locking time on InnoDB tables.", NULL},
     {"trx-consistency-only", 0, 0, G_OPTION_ARG_NONE, &trx_consistency_only,
      "Transactional consistency only", NULL},
+    {"skip-ddl-locks", 0, 0, G_OPTION_ARG_NONE, &skip_ddl_locks, "Do not send DDL locks when possible", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 

--- a/src/mydumper_global.h
+++ b/src/mydumper_global.h
@@ -43,6 +43,7 @@ extern int longquery;
 extern int longquery_retry_interval;
 extern int longquery_retries;
 extern int lock_all_tables;
+extern gboolean skip_ddl_locks;
 extern gboolean no_backup_locks;
 extern gchar *logfile;
 extern gboolean help;

--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -86,6 +86,7 @@ int need_dummy_read = 0;
 int need_dummy_toku_read = 0;
 int killqueries = 0;
 int lock_all_tables = 0;
+gboolean skip_ddl_locks= FALSE;
 gboolean replica_stopped = FALSE;
 gboolean no_locks = FALSE;
 gboolean it_is_a_consistent_backup = FALSE;
@@ -1164,6 +1165,10 @@ void start_dump() {
     if (!no_locks) {
       // This backup will lock the database
       determine_ddl_lock_function(&second_conn, &acquire_global_lock_function,&release_global_lock_function, &acquire_ddl_lock_function, &release_ddl_lock_function, &release_binlog_function);
+      if (skip_ddl_locks){
+        acquire_ddl_lock_function=NULL;
+        release_ddl_lock_function=NULL;
+      }
 
       if (lock_all_tables) {
         send_lock_all_tables(conn);


### PR DESCRIPTION
I based the test on https://github.com/mydumper/mydumper/issues/8 to reproduce the expected behavior.
I had 3 sbtest tables on sbtest database with 1M rows.
Without --skip-ddl-lock, we expected this:
```
root@ubuntu-jammy:~/issue_1297/mydumper# ./mydumper --clear -o data  -v 3 --rows=100:1000000:0  -B sbtest -t 2
** Message: 15:08:20.168: MyDumper backup version: 0.16.1-1
** Message: 15:08:20.231: Using 2 dumper threads
** Message: 15:08:20.234: Connection via default library settings
** Message: 15:08:20.235: Connected to Percona 5.7.44
** Message: 15:08:20.235: Started dump at: 2024-03-12 15:08:20
** Message: 15:08:20.236: Acquiring DDL lock
** Message: 15:08:20.236: LOCK TABLES FOR BACKUP: OK
** Message: 15:08:20.236: LOCK BINLOG FOR BACKUP: OK
** Message: 15:08:20.236: Acquiring Global lock
** Message: 15:08:20.237: FLUSH NO_WRITE_TO_BINLOG TABLES: OK
** Message: 15:08:20.237: FLUSH TABLES WITH READ LOCK: OK
** Message: 15:08:20.237: conf created
** Message: 15:08:20.237: End job creation
** Message: 15:08:20.237: Creating workers
** Message: 15:08:20.237: Starting Non-InnoDB tables
** Message: 15:08:20.239: Thread 2: connected using MySQL connection ID 673
** Message: 15:08:20.240: Thread 1: connected using MySQL connection ID 672
** Message: 15:08:20.242: Thread 2: Creating Jobs
** Message: 15:08:20.243: Thread 1: Creating Jobs
** Message: 15:08:20.243: Thread 1: dumping db information for `sbtest`
** Message: 15:08:20.243: Waiting database finish
** Message: 15:08:20.247: Thread 1: Schema queue
** Message: 15:08:20.247: Thread 2: Schema queue
** Message: 15:08:20.247: Thread 1: dumping schema create for `sbtest`
** Message: 15:08:20.247: Thread 2: dumping schema for `sbtest`.`sbtest1`
** Message: 15:08:20.247: Shutdown jobs for less locking enqueued
** Message: 15:08:20.247: Thread 1: dumping schema for `sbtest`.`sbtest2`
** Message: 15:08:20.247: Thread 2: dumping schema for `sbtest`.`sbtest3`
** Message: 15:08:20.248: Thread 1: Schema Done, Starting Non-Innodb
** Message: 15:08:20.248: Non-InnoDB tables completed
** Message: 15:08:20.248: Starting InnoDB tables
** Message: 15:08:20.248: Thread 1: Non-Innodb Done, Starting Innodb
** Message: 15:08:20.248: Thread 2: Schema Done, Starting Non-Innodb
** Message: 15:08:20.248: Thread 2: Non-Innodb Done, Starting Innodb
** Message: 15:08:20.248: Non-InnoDB dump complete, releasing global locks
** Message: 15:08:20.248: UNLOCK TABLES: OK
** Message: 15:08:20.248: Global locks released
** Message: 15:08:20.248: sbtest.sbtest3 has ~986400 rows
** Message: 15:08:20.248: Releasing binlog lock
** Message: 15:08:20.248: UNLOCK BINLOG: OK
** Message: 15:08:20.249: sbtest.sbtest2 has ~986400 rows
** Message: 15:08:20.249: sbtest.sbtest1 has ~986400 rows
** Message: 15:08:20.249: InnoDB tables completed
** Message: 15:08:20.249: Waiting threads to complete
** Message: 15:08:20.250: Thread 1: dumping data for `sbtest`.`sbtest3`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))       into data/sbtest.sbtest3.00000.sql| Remaining jobs in this table: 1 All remaining jobs: 0
** Message: 15:08:20.250: Thread 2: dumping data for `sbtest`.`sbtest2`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))       into data/sbtest.sbtest2.00000.sql| Remaining jobs in this table: 1 All remaining jobs: 0
** Message: 15:08:22.935: Thread 2: dumping data for `sbtest`.`sbtest1`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))       into data/sbtest.sbtest1.00000.sql| Remaining jobs in this table: 1 All remaining jobs: 0
** Message: 15:08:23.097: Thread 1: dumping triggers for `sbtest`
** Message: 15:08:23.098: Thread 1: shutting down
** Message: 15:08:25.137: Thread 2: shutting down
** Message: 15:08:25.138: Releasing DDL lock
** Message: 15:08:25.138: UNLOCK TABLES: OK
** Message: 15:08:25.138: Queue count: 0 0 0 0 0
** Message: 15:08:25.138: Main connection closed
** Message: 15:08:25.141: Finished dump at: 2024-03-12 15:08:25
```
Even if we send DROP TABLE before dumping `sbtest`.`sbtest1`:
However if we use --skip-ddl-locks:
```
root@ubuntu-jammy:~/issue_1297/mydumper# ./mydumper --clear -o data  -v 3 --rows=100:1000000:0  --skip-ddl-locks -B sbtest -t 2
** Message: 15:07:33.773: MyDumper backup version: 0.16.1-1
** Message: 15:07:33.862: Using 2 dumper threads
** Message: 15:07:33.866: Connection via default library settings
** Message: 15:07:33.869: Connected to Percona 5.7.44
** Message: 15:07:33.869: Started dump at: 2024-03-12 15:07:33
** Message: 15:07:33.872: Acquiring Global lock
** Message: 15:07:33.873: FLUSH NO_WRITE_TO_BINLOG TABLES: OK
** Message: 15:07:33.873: FLUSH TABLES WITH READ LOCK: OK
** Message: 15:07:33.874: conf created
** Message: 15:07:33.874: End job creation
** Message: 15:07:33.874: Creating workers
** Message: 15:07:33.874: Starting Non-InnoDB tables
** Message: 15:07:33.877: Thread 1: connected using MySQL connection ID 668
** Message: 15:07:33.878: Thread 2: connected using MySQL connection ID 669
** Message: 15:07:33.882: Thread 2: Creating Jobs
** Message: 15:07:33.882: Thread 1: Creating Jobs
** Message: 15:07:33.884: Waiting database finish
** Message: 15:07:33.884: Thread 1: dumping db information for `sbtest`
** Message: 15:07:33.898: Thread 2: Schema queue
** Message: 15:07:33.898: Thread 2: dumping schema create for `sbtest`
** Message: 15:07:33.900: Thread 1: Schema queue
** Message: 15:07:33.901: Thread 1: dumping schema for `sbtest`.`sbtest1`
** Message: 15:07:33.901: Shutdown jobs for less locking enqueued
** Message: 15:07:33.910: Thread 1: dumping schema for `sbtest`.`sbtest2`
** Message: 15:07:33.910: Thread 2: dumping schema for `sbtest`.`sbtest3`
** Message: 15:07:33.913: Thread 2: Schema Done, Starting Non-Innodb
** Message: 15:07:33.913: Non-InnoDB tables completed
** Message: 15:07:33.913: Starting InnoDB tables
** Message: 15:07:33.913: Thread 2: Non-Innodb Done, Starting Innodb
** Message: 15:07:33.913: Thread 1: Schema Done, Starting Non-Innodb
** Message: 15:07:33.914: Thread 1: Non-Innodb Done, Starting Innodb
** Message: 15:07:33.914: Non-InnoDB dump complete, releasing global locks
** Message: 15:07:33.914: sbtest.sbtest3 has ~986400 rows
** Message: 15:07:33.915: UNLOCK TABLES: OK
** Message: 15:07:33.915: Global locks released
** Message: 15:07:33.915: Releasing binlog lock
** Message: 15:07:33.915: UNLOCK BINLOG: OK
** Message: 15:07:33.915: sbtest.sbtest2 has ~986400 rows
** Message: 15:07:33.917: sbtest.sbtest1 has ~986400 rows
** Message: 15:07:33.917: InnoDB tables completed
** Message: 15:07:33.919: Thread 2: dumping data for `sbtest`.`sbtest3`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))       into data/sbtest.sbtest3.00000.sql| Remaining jobs in this table: 1 All remaining jobs: 0
** Message: 15:07:33.920: Thread 1: dumping data for `sbtest`.`sbtest2`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))       into data/sbtest.sbtest2.00000.sql| Remaining jobs in this table: 1 All remaining jobs: 0
** Message: 15:07:33.922: Waiting threads to complete
** Message: 15:07:36.598: Thread 2: dumping triggers for `sbtest`
** Message: 15:07:36.599: Thread 2: shutting down

** (mydumper:13885): CRITICAL **: 15:07:36.645: Thread 1: Error dumping table (sbtest.sbtest1) data: Table 'sbtest.sbtest1' doesn't exist
Query: SELECT /*!40001 SQL_NO_CACHE */ * FROM `sbtest`.`sbtest1`  WHERE (`id` IS NULL OR(1 <= `id` AND `id` <= 1000000))
** Message: 15:07:36.645: Thread 1: shutting down
** Message: 15:07:36.645: Queue count: 0 0 0 0 0
** Message: 15:07:36.645: Main connection closed
** Message: 15:07:36.645: Finished dump at: 2024-03-12 15:07:36
```
We get an error as the table doesn't exists. 