### PR TITLE
[bug] Fix --max-threads-per-table not working with myloader

### DIFF
--- a/src/myloader_control_job.c
+++ b/src/myloader_control_job.c
@@ -259,6 +259,7 @@ gboolean give_me_next_data_job_conf(struct configuration *conf, gboolean test_co
       if (dbt->schema_state == CREATED && g_list_length(dbt->restore_job_list) > 0){
         if (dbt->current_threads >= dbt->max_threads ){
           giveup=FALSE;
+          iter=iter->next;
           g_mutex_unlock(dbt->mutex);
           continue;
         }


### PR DESCRIPTION
In the latest mydumper (compiled from source), `--max-threads-per-table` is not working with `myloader`. It just creates `max-threads-per-table` threads for the first table and sits there, not using the other `--threads` it should.

It looks like that's caused by a missed iteration step when looking for tables that can be worked on.