### PR TITLE
Fix building on Fedora 40

### DIFF
--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -302,8 +302,8 @@ void initialize_sql_mode(GHashTable * set_session_hash){
   GString *str= g_string_new(sql_mode);
   g_string_replace(str, "ORACLE", "", 0);
   g_string_replace(str, ",,", ",", 0);
-  set_session_hash_insert(set_session_hash, "SQL_MODE", str->str);
-  g_string_free(str, FALSE);
+  set_session_hash_insert(set_session_hash, "SQL_MODE",
+		  g_string_free(str, FALSE));
 }
 
 
@@ -397,9 +397,8 @@ void detect_sql_mode(MYSQL *conn){
   g_string_replace(str, ",,", ",", 0);
   g_string_replace(str, "STRICT_TRANS_TABLES", "", 0);
   g_string_replace(str, ",,", ",", 0);
-  sql_mode= str->str;
+  sql_mode= g_string_free(str, FALSE);
   g_assert(sql_mode);
-  g_string_free(str, FALSE);
   mysql_free_result(res);
 }
 


### PR DESCRIPTION
Before:

```
$ make
[  1%] Building C object CMakeFiles/mydumper.dir/src/mydumper.c.o
[  3%] Building C object CMakeFiles/mydumper.dir/src/server_detect.c.o
[  5%] Building C object CMakeFiles/mydumper.dir/src/connection.c.o
[  7%] Building C object CMakeFiles/mydumper.dir/src/logging.c.o
[  9%] Building C object CMakeFiles/mydumper.dir/src/set_verbose.c.o
[ 11%] Building C object CMakeFiles/mydumper.dir/src/common.c.o
[ 13%] Building C object CMakeFiles/mydumper.dir/src/tables_skiplist.c.o
[ 15%] Building C object CMakeFiles/mydumper.dir/src/regex.c.o
[ 17%] Building C object CMakeFiles/mydumper.dir/src/mydumper_pmm_thread.c.o
[ 19%] Building C object CMakeFiles/mydumper.dir/src/mydumper_start_dump.c.o
In file included from /usr/include/glib-2.0/glib/giochannel.h:36,
                 from /usr/include/glib-2.0/glib.h:56,
                 from /home/dvaneeden/dev/mydumper/src/mydumper_start_dump.c:34:
/home/dvaneeden/dev/mydumper/src/mydumper_start_dump.c: In function ‘initialize_sql_mode’:
/usr/include/glib-2.0/glib/gstring.h:74:5: error: ignoring return value of ‘g_string_free_and_steal’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   70 |   (__builtin_constant_p (free_segment) ?        \
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   71 |     ((free_segment) ?                           \
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |       (g_string_free) ((str), (free_segment)) : \
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |       g_string_free_and_steal (str))            \
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   74 |     :                                           \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   75 |     (g_string_free) ((str), (free_segment)))
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dvaneeden/dev/mydumper/src/mydumper_start_dump.c:306:3: note: in expansion of macro ‘g_string_free’
  306 |   g_string_free(str, FALSE);
      |   ^~~~~~~~~~~~~
/home/dvaneeden/dev/mydumper/src/mydumper_start_dump.c: In function ‘detect_sql_mode’:
/usr/include/glib-2.0/glib/gstring.h:74:5: error: ignoring return value of ‘g_string_free_and_steal’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   70 |   (__builtin_constant_p (free_segment) ?        \
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   71 |     ((free_segment) ?                           \
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |       (g_string_free) ((str), (free_segment)) : \
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |       g_string_free_and_steal (str))            \
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   74 |     :                                           \
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   75 |     (g_string_free) ((str), (free_segment)))
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/dvaneeden/dev/mydumper/src/mydumper_start_dump.c:402:3: note: in expansion of macro ‘g_string_free’
  402 |   g_string_free(str, FALSE);
      |   ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/mydumper.dir/build.make:202: CMakeFiles/mydumper.dir/src/mydumper_start_dump.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:103: CMakeFiles/mydumper.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

```
$ rpm -qf /usr/include/glib-2.0/glib/gstring.h
glib2-devel-2.80.2-1.fc40.x86_64
$ rpm -q gcc
gcc-14.1.1-1.fc40.x86_64
```