### PR TITLE
Fixing start replica issues

### DIFF
--- a/src/mydumper_start_dump.c
+++ b/src/mydumper_start_dump.c
@@ -1372,6 +1372,7 @@ void start_dump() {
       if (mysql_query(conn, start_replica_sql_thread)){
         g_warning("Not able to start replica: %s", mysql_error(conn));
       }
+      replica_stopped=FALSE;
     }
   }
 
@@ -1420,13 +1421,14 @@ void start_dump() {
       g_message("Releasing binlog lock");
       release_binlog_function(second_conn);
     }
-    if (replica_stopped){
-      g_message("Starting replica");
-      if (mysql_query(conn, start_replica_sql_thread)){
-        g_warning("Not able to start replica: %s", mysql_error(conn));
-      }
+  }
+  if (replica_stopped){
+    g_message("Starting replica");
+    if (mysql_query(conn, start_replica_sql_thread)){
+      g_warning("Not able to start replica: %s", mysql_error(conn));
     }
   }
+  
 
   g_async_queue_unref(conf.binlog_ready);
 


### PR DESCRIPTION
In this case we are taking into account any scenario, that the replica has been stopped. We consider replica_stopped as the status of the replica to determine if we need to start it or not.