### PR TITLE
Fix building on musl libc

### DIFF
--- a/src/mydumper_file_handler.c
+++ b/src/mydumper_file_handler.c
@@ -40,6 +40,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <sys/file.h>
+#include <fcntl.h>
 
 GAsyncQueue *close_file_queue=NULL;
 GAsyncQueue *available_pids=NULL;

--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -26,6 +26,7 @@
 #include "mydumper_stream.h"
 #include <sys/file.h>
 #include <errno.h>
+#include <fcntl.h>
 
 extern GAsyncQueue *stream_queue;
 


### PR DESCRIPTION
On musl libc we are getting buid errors:
mydumper/src/mydumper_stream.c:100:9: error: implicit declaration of function 'open'; did you mean 'popen'? [-Wimplicit- function-declaration]
  100 |       f=open(sf->filename,O_RDONLY);
      |         ^~~~
      |         popen
mydumper/src/mydumper_stream.c:100:27: error: 'O_RDONLY' undeclared (first use in this function)
  100 |       f=open(sf->filename,O_RDONLY);
      |                           ^~~~~~~~
This probably due to musl being more strict. Fix was to include the
fcntl.h header file as the Linux Manual Page suggests open should come
from fcntl.h

First reported on Gentoo Linux with musl profile

Bug: https://bugs.gentoo.org/935389