### PR TITLE
fix build error

### DIFF
--- a/src/mydumper_stream.c
+++ b/src/mydumper_stream.c
@@ -94,7 +94,7 @@ void *process_stream(void *data){
     total_size+=strlen(used_filemame);
     free(used_filemame);
     if (no_stream){
-      write(fileno(stdout), "0\n", 2);
+      f=write(fileno(stdout), "0\n", 2);
     }else{
 //      g_message("Stream Opening: %s",sf->filename);
       f=open(sf->filename,O_RDONLY);


### PR DESCRIPTION
mydumper/src/mydumper_stream.c:97:7: error: ignoring return value of ‘write’, declared with attribute warn_unused_result [-Werror=unused-result]

gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0
cmake version 3.16.3
GNU Make 4.2.1