### PR TITLE
Adding --ignore-set on myloader

### DIFF
--- a/src/myloader_arguments.c
+++ b/src/myloader_arguments.c
@@ -36,6 +36,7 @@ gchar *innodb_optimize_keys_str=NULL;
 gchar *checksum_str=NULL;
 guint source_control_command = TRADITIONAL;
 gboolean set_gtid_purge = FALSE;
+gchar *ignore_set=NULL;
 
 gboolean arguments_callback(const gchar *option_name,const gchar *value, gpointer data, GError **error){
   *error=NULL;
@@ -213,6 +214,7 @@ static GOptionEntry statement_entries[] ={
       "Sets the names, use it at your own risk, default binary", NULL },
     {"skip-definer", 0, 0, G_OPTION_ARG_NONE, &skip_definer,
      "Removes DEFINER from the CREATE statement. By default, statements are not modified", NULL},
+    { "ignore-set", 0, 0, G_OPTION_ARG_STRING, &ignore_set, "List of variables that will be ignored from the header of SET", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 

--- a/src/myloader_common.c
+++ b/src/myloader_common.c
@@ -46,8 +46,18 @@ struct database *database_db=NULL;
 guint refresh_table_list_interval=100;
 guint refresh_table_list_counter=1;
 gchar *source_gtid=NULL;
+GList *ignore_set_list=NULL;
 
 void initialize_common(){
+  if (ignore_set){
+    gchar** ignore_set_items= g_strsplit(ignore_set, ",", 0);
+    guint i=0;
+    for (i=0; g_strv_length(ignore_set_items)>i; i++){
+      ignore_set_list=g_list_prepend(ignore_set_list,g_strdup_printf(" %s",ignore_set_items[i]));
+    }
+    g_strfreev(ignore_set_items);
+  }
+  
   refresh_table_list_counter=refresh_table_list_interval;
   db_hash_mutex=g_mutex_new();
   tbl_hash=g_hash_table_new ( g_str_hash, g_str_equal );
@@ -55,6 +65,21 @@ void initialize_common(){
   if (db){
     database_db=get_db_hash(g_strdup(db), g_strdup(db));
   }
+}
+
+gboolean is_in_list(gchar *haystack, GList *list){
+  GList *l=list;
+  while(l){
+    if (g_strrstr(haystack, l->data)){
+      return TRUE;
+    }
+    l=l->next;
+  }
+  return FALSE;
+}
+
+gboolean is_in_ignore_set_list(gchar *haystack){
+  return is_in_list(haystack,ignore_set_list);
 }
 
 

--- a/src/myloader_common.h
+++ b/src/myloader_common.h
@@ -54,4 +54,5 @@ void change_master(GKeyFile * kf,gchar *group, GString *s);
 gboolean get_command_and_basename(gchar *filename, gchar ***command, gchar **basename);
 gboolean m_filename_has_suffix(gchar const *str, gchar const *suffix);
 void initialize_thread_data(struct thread_data*td, struct configuration *conf, enum thread_states status, guint thread_id, struct db_table *dbt);
+gboolean is_in_ignore_set_list(gchar *haystack);
 #endif

--- a/src/myloader_global.h
+++ b/src/myloader_global.h
@@ -125,4 +125,4 @@ extern gboolean kill_at_once;
 extern struct configuration_per_table conf_per_table;
 extern guint source_control_command;
 extern gboolean set_gtid_purge;
-
+extern gchar *ignore_set;

--- a/src/myloader_restore.c
+++ b/src/myloader_restore.c
@@ -532,7 +532,18 @@ int restore_data_from_file(struct thread_data *td, const char *filename, gboolea
             m_remove(NULL, load_data_filename);
         }else{
           if (g_strrstr_len(data->str,3,"/*!")){
-            g_string_append(header,data->str);
+            gchar *from_equal=g_strstr_len(data->str, strlen(data->str),"=");
+            if (from_equal && ignore_set ){
+            *from_equal='\0';
+            if (!is_in_ignore_set_list(data->str)) {
+              *from_equal='=';
+              g_string_append(header,data->str);
+            }else{
+              *from_equal='=';
+            }
+            }else{
+              g_string_append(header,data->str);
+            }
           }else{
             header=NULL;
           }


### PR DESCRIPTION
This option allows users to ignore SET options in what myloaders consider HEADER in the sql file. 