### PR TITLE
fix: compiler warning for possible uninitialized `write_column_into_string`

### DIFF
--- a/src/mydumper_write.c
+++ b/src/mydumper_write.c
@@ -634,7 +634,7 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
   gulong *lengths = NULL;
   guint64 num_rows=0;
   guint64 num_rows_st = 0;
-  void (*write_column_into_string)(MYSQL *, gchar **, MYSQL_FIELD , gulong ,GString *, GString *, struct function_pointer * );
+  void (*write_column_into_string)(MYSQL *, gchar **, MYSQL_FIELD , gulong ,GString *, GString *, struct function_pointer *) = write_sql_column_into_string;
   switch (output_format){
     case LOAD_DATA:
     case CSV:
@@ -654,7 +654,6 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       }
 	  	break;
     case CLICKHOUSE:
-      write_column_into_string=write_sql_column_into_string;
       if (tj->rows->file == 0){
         update_files_on_table_job(tj);
       }
@@ -677,7 +676,6 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       g_string_append(statement, dbt->insert_statement->str);
       break;
 		case SQL_INSERT:
-  		write_column_into_string=write_sql_column_into_string;
       if (tj->rows->file == 0){
         update_files_on_table_job(tj);
   		}


### PR DESCRIPTION
Compiling with `-Werror=maybe-uninitialized` causes the compiler to complain about an eventually *possible* use of unititialized write_colum_into_string function pointer.

```
mydumper/src/mydumper-0.16.7-5/src/mydumper_write.c:703:17: error: ‘write_column_into_string’ may be used uninitialized [-Werror=maybe-uninitialized]
  703 |                 write_row_into_string(conn, dbt, row, fields, lengths, num_fields, escaped, statement_row, write_column_into_string);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mydumper/src/mydumper-0.16.7-5/src/mydumper_write.c:637:10: note: ‘write_column_into_string’ was declared here
  637 |   void (*write_column_into_string)(MYSQL *, gchar **, MYSQL_FIELD , gulong ,GString *, GString *, struct function_pointer * );
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [CMakeFiles/mydumper.dir/build.make:342: CMakeFiles/mydumper.dir/src/mydumper_write.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:86: CMakeFiles/mydumper.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
``` 