### PR TITLE
Creating a tmp fifo directory

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -517,26 +517,19 @@ void escape_tab_with(gchar *to){
 }
 
 
-void create_fifo_dir(char *new_fifo_directory) {
-  if (new_fifo_directory){
-    if (g_mkdir(new_fifo_directory, 0750) == -1) {
-      if (errno != EEXIST) {
-        m_critical("Unable to create `%s': %s", new_fifo_directory, g_strerror(errno));
-      }
+gboolean create_dir(char *directory){
+  if (g_mkdir(directory, 0750) == -1) {
+    if (errno != EEXIST) {
+      m_critical("Unable to create `%s': %s", directory, g_strerror(errno));
     }
-  }else{
-    g_warning("Fifo directoy provided was invalid");
+    return FALSE;
   }
+  return TRUE;
 }
 
-void create_backup_dir(char *new_directory, char *new_fifo_directory) {
-  if (g_mkdir(new_directory, 0750) == -1) {
-    if (errno != EEXIST) {
-      m_critical("Unable to create `%s': %s", new_directory, g_strerror(errno));
-    }
-  }
-  if (new_fifo_directory)
-    create_fifo_dir(new_fifo_directory);
+gchar *build_tmp_dir_name(){
+  GError*error=NULL;
+  return g_dir_make_tmp (NULL, &error);
 }
 
 guint strcount(gchar *text){

--- a/src/common.h
+++ b/src/common.h
@@ -110,8 +110,6 @@ char * checksum_view_structure(MYSQL *conn, char *database, char *table, int *er
 char * checksum_database_defaults(MYSQL *conn, char *database, char *table, int *errn);
 char * checksum_table_indexes(MYSQL *conn, char *database, char *table, int *errn);
 int write_file(FILE * file, char * buff, int len);
-void create_backup_dir(char *new_directory, char *new_fifo_directory);
-void create_fifo_dir(char *new_fifo_directory);
 guint strcount(gchar *text);
 void m_remove0(gchar * directory, const gchar * filename);
 gboolean m_remove(gchar * directory, const gchar * filename);
@@ -199,3 +197,5 @@ gchar *build_dbt_key(gchar *a, gchar *b);
 gboolean common_arguments_callback(const gchar *option_name,const gchar *value, gpointer data, GError **error);
 void discard_mysql_output(MYSQL *conn);
 gboolean m_query(  MYSQL *conn, const gchar *query, void log_fun(const char *, ...) , const char *fmt, ...);
+gboolean create_dir(gchar *directory);
+gchar *build_tmp_dir_name();

--- a/src/common_options.c
+++ b/src/common_options.c
@@ -35,7 +35,6 @@ char *defaults_extra_file = NULL;
 //gchar *ssl_mode = NULL;
 #endif
 
-gchar *fifo_directory = NULL;
 gboolean help =FALSE;
 int detected_server = 0;
 GString *set_session = NULL;
@@ -86,8 +85,6 @@ GOptionEntry common_entries[] = {
      "Use a specific defaults file. Default: /etc/mydumper.cnf", NULL},
     {"defaults-extra-file", 0, 0, G_OPTION_ARG_FILENAME, &defaults_extra_file,
      "Use an additional defaults file. This is loaded after --defaults-file, replacing previous defined values", NULL},
-    {"fifodir", 0, 0, G_OPTION_ARG_FILENAME, &fifo_directory,
-     "Directory where the FIFO files will be created when needed. Default: Same as backup", NULL},
     {"source-control-command", 0, 0, G_OPTION_ARG_CALLBACK, &common_arguments_callback,
       "Instruct the proper commands to execute depending where are configuring the replication. Options: TRADITIONAL, AWS", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};

--- a/src/mydumper.c
+++ b/src/mydumper.c
@@ -260,11 +260,10 @@ int main(int argc, char *argv[]) {
     print_bool("debug",debug);
     print_string("defaults-file",defaults_file);
     print_string("defaults-extra-file",defaults_extra_file);
-    print_string("fifodir",fifo_directory);
     exit(EXIT_SUCCESS);
   }
   
-  create_backup_dir(output_directory, NULL);
+  create_dir(output_directory);
 
   if (disk_limits!=NULL){
     parse_disk_limits();

--- a/src/mydumper_daemon_thread.c
+++ b/src/mydumper_daemon_thread.c
@@ -55,7 +55,7 @@ void initialize_daemon_thread(){
     char *d_d;
     for (dump_number = 0; dump_number < snapshot_count; dump_number++) {
         d_d= g_strdup_printf("%s/%d", output_directory, dump_number);
-        create_backup_dir(d_d,NULL);
+        create_dir(d_d);
         g_free(d_d);
     }
 

--- a/src/mydumper_global.h
+++ b/src/mydumper_global.h
@@ -141,7 +141,6 @@ extern const gchar *compress_method;
 extern guint64 min_chunk_step_size;
 extern guint64 max_chunk_step_size;
 extern gboolean compact;
-extern gchar *fifo_directory;
 extern gboolean split_integer_tables;
 extern const gchar *rows_file_extension;
 extern guint source_data;

--- a/src/myloader.c
+++ b/src/myloader.c
@@ -297,7 +297,7 @@ int main(int argc, char *argv[]) {
       datetimestr=g_date_time_format(datetime,"\%Y\%m\%d-\%H\%M\%S");
 
       directory = g_strdup_printf("%s/%s-%s",current_dir, DIRECTORY, datetimestr);
-      create_backup_dir(directory,fifo_directory);
+      create_dir(directory);
       g_date_time_unref(datetime);
       g_free(datetimestr); 
     }else{
@@ -308,7 +308,7 @@ int main(int argc, char *argv[]) {
     directory=g_str_has_prefix(input_directory,"/")?input_directory:g_strdup_printf("%s/%s", current_dir, input_directory);
     if (stream){
       if (!g_file_test(input_directory,G_FILE_TEST_IS_DIR)){
-        create_backup_dir(directory,fifo_directory);
+        create_dir(directory);
       }else{
         if (!no_stream){
           m_critical("Backup directory (-d) must not exist when --stream / --stream=TRADITIONAL");
@@ -330,10 +330,12 @@ int main(int argc, char *argv[]) {
       gchar *tmp_fifo_directory=fifo_directory;
       fifo_directory=g_strdup_printf("%s/%s", current_dir, tmp_fifo_directory);
     }
-    create_fifo_dir(fifo_directory);
   }else{
-    fifo_directory=directory;
+    // Create temporary director
+    fifo_directory=build_tmp_dir_name();
   }
+  create_dir(fifo_directory);
+  g_message("Using %s as FIFO directory, please remove it if restoration fails", fifo_directory);
 
   if (help){
     print_string("host", hostname);
@@ -662,7 +664,7 @@ int main(int argc, char *argv[]) {
 */
 
   if (key_file)  g_key_file_free(key_file);
-
+  g_remove(fifo_directory);
   return errors ? EXIT_FAILURE : EXIT_SUCCESS;
 }
 

--- a/src/myloader_arguments.c
+++ b/src/myloader_arguments.c
@@ -36,6 +36,7 @@ gchar *innodb_optimize_keys_str=NULL;
 gchar *checksum_str=NULL;
 gboolean set_gtid_purge = FALSE;
 gchar *ignore_set=NULL;
+gchar *fifo_directory = NULL;
 
 gboolean arguments_callback(const gchar *option_name,const gchar *value, gpointer data, GError **error){
   *error=NULL;
@@ -100,6 +101,8 @@ static GOptionEntry entries[] = {
      "Directory of the dump to import", NULL},
     {"logfile", 'L', 0, G_OPTION_ARG_FILENAME, &logfile,
      "Log file name to use, by default stdout is used", NULL},
+    {"fifodir", 0, 0, G_OPTION_ARG_FILENAME, &fifo_directory,
+     "Directory where the FIFO files will be created when needed. Default: Same as backup", NULL},
     {"database", 'B', 0, G_OPTION_ARG_STRING, &db,
      "An alternative database to restore into", NULL},
     {"quote-character", 'Q', 0, G_OPTION_ARG_CALLBACK, &arguments_callback,

--- a/src/myloader_process.c
+++ b/src/myloader_process.c
@@ -161,14 +161,17 @@ FILE * myl_open(char *filename, const char *type){
       fifoname=g_strdup_printf("%s/%s", fifo_directory, basefilename);
       g_free(basename);
     }
-
-
-    lstat(fifoname, &a);
-    if ((a.st_mode & S_IFMT) == S_IFIFO){
-      g_warning("FIFO file found %s, removing and continuing", fifoname);
-      remove(fifoname);
+// This 2 lines simulates if a common file or a fifo file is present in the fifo dir:
+//    g_file_set_contents(fifoname, "   ",2,NULL );
+//    mkfifo(fifoname,0666);
+    if (g_file_test(fifoname, G_FILE_TEST_EXISTS)){
+      lstat(fifoname, &a);
+      g_message("FIFO file: %s", filename);
+      if ((a.st_mode & S_IFMT) == S_IFIFO){
+        g_warning("FIFO file found %s, removing and continuing", fifoname);
+        remove(fifoname);
+      }
     }
-
     if (mkfifo(fifoname,0666)){
       g_critical("cannot create named pipe %s (%d)", fifoname, errno); 
     }

--- a/test_mydumper.sh
+++ b/test_mydumper.sh
@@ -205,7 +205,6 @@ test_case_dir (){
     echo "Exporting database: ${mydumper_parameters}"
     rm -rf /tmp/fifodir
     "${time2[@]}" $mydumper -u root -M $log_level -L $tmp_mydumper_log ${mydumper_parameters}
-exit
     error=$?
     cat $tmp_mydumper_log >> $mydumper_log
     if (( $error > 0 ))

--- a/test_mydumper.sh
+++ b/test_mydumper.sh
@@ -61,8 +61,14 @@ fi
 
 if [ -z "$MYSQLX_UNIX_PORT" -a -z "$MYSQL_UNIX_PORT" ]
 then
-#  export MYSQL_HOST=127.0.0.1
-  export MYSQL_TCP_PORT=3306
+  if [ -z "${MYSQL_HOST}" ];
+  then
+    export MYSQL_HOST=127.0.0.1
+  fi
+  if [ -z "${MYSQL_TCP_PORT}" ];
+  then
+    export MYSQL_TCP_PORT=3306
+  fi
   echo "Using TCP connection to $MYSQL_HOST:$MYSQL_TCP_PORT"
 fi
 
@@ -199,6 +205,7 @@ test_case_dir (){
     echo "Exporting database: ${mydumper_parameters}"
     rm -rf /tmp/fifodir
     "${time2[@]}" $mydumper -u root -M $log_level -L $tmp_mydumper_log ${mydumper_parameters}
+exit
     error=$?
     cat $tmp_mydumper_log >> $mydumper_log
     if (( $error > 0 ))
@@ -384,7 +391,7 @@ prepare_full_test()
   if [[ -n "$prepare_only"  ]]; then
     exit
   fi
-  mydumper_general_options="-u root -R -E -G -o ${mydumper_stor_dir} --regex "'^(?!(mysql\.|sys\.))'" --fifodir=/tmp/fifodir $log_level $MYDUMPER_ARGS"
+  mydumper_general_options="-u root -R -E -G -o ${mydumper_stor_dir} --regex "'^(?!(mysql\.|sys\.))'" $log_level $MYDUMPER_ARGS"
   myloader_general_options="-o --max-threads-for-index-creation=1 --max-threads-for-post-actions=1  --fifodir=/tmp/fifodir $log_level $MYLOADER_ARGS"
 }
 


### PR DESCRIPTION
We added the `Using <DIR> as FIFO directory...` line to inform users what fifo directory we are using:
```
circleci@f7116bec80a9:~/issue_1478/mydumper$ ./myloader -u root -o -v 4 -d data/ --serialized-table-creation  -h 172.17.0.4
** Message: 11:46:30.780: Using 4 loader threads
** Message: 11:46:30.788: Config file loaded
** Message: 11:46:30.788: Using /tmp/.SPPJU2 as FIFO directory, please remove it if restoration fails
** Message: 11:46:30.850: Connection via default library settings:
	Host: 172.17.0.4
	User: root
** Message: 11:46:30.853: Initializing initialize_worker_schema
** Message: 11:46:30.853: S-Thread 5: Starting import
** Message: 11:46:30.856: Reading metadata: metadata
** Message: 11:46:30.857: Intermediate queue: Sending END job
** Message: 11:46:30.857: Thread 5: restoring create database on `sakila` from sakila-schema-create.sql.zst. Tables 0 of 1 completed
** Message: 11:46:30.871: Intermediate thread ended
** Message: 11:46:30.871: Thread 5: restoring table sakila.film_actor from /home/circleci/project/issue_1478/mydumper/data/sakila.film_actor-schema.sql.zst
** Message: 11:46:30.871: Dropping table or view (if exists) sakila.film_actor
** Message: 11:46:30.872: Intermediate thread: SHUTDOWN
** Message: 11:46:30.878: Thread 5: Creating table sakila.film_actor from content in /home/circleci/project/issue_1478/mydumper/data/sakila.film_actor-schema.sql.zst. On db: sakila
** Message: 11:46:30.889: Thread 5: Table sakila.film_actor created. Tables that pass created stage: 0 of 1
** Message: 11:46:30.889: Schema creation enqueing completed
** Message: 11:46:30.889: Table creation enqueing completed
** Message: 11:46:30.889: S-Thread 5: Import completed
** Message: 11:46:30.890: Thread 2: restoring sakila.film_actor part 3 of 4 from sakila.film_actor.00000.00002.sql.zst | Progress 1 of 4. Tables 0 of 1 completed
** Message: 11:46:30.890: Thread 3: restoring sakila.film_actor part 2 of 4 from sakila.film_actor.00000.00094.sql.zst | Progress 2 of 4. Tables 0 of 1 completed
** Message: 11:46:30.890: Thread 1: restoring sakila.film_actor part 4 of 4 from sakila.film_actor.00000.00120.sql.zst | Progress 3 of 4. Tables 0 of 1 completed
** Message: 11:46:30.891: Thread 4: restoring sakila.film_actor part 1 of 4 from sakila.film_actor.00000.00201.sql.zst | Progress 4 of 4. Tables 0 of 1 completed
** Message: 11:46:30.905: Thread 4: Data import ended
** Message: 11:46:30.915: Thread 3: Data import ended
** Message: 11:46:30.925: Thread 2: Data import ended
** Message: 11:46:30.929: Thread 1: Data import ended
** Message: 11:46:30.929: Thread 10: Starting post import task over table
** Message: 11:46:30.929: Thread 10: restoring constraints sakila.film_actor from /home/circleci/project/issue_1478/mydumper/data/sakila.film_actor-schema.sql.zst. Tables 1 of 1 completed
** Message: 11:46:30.936: Errors found:
- Tablespace:	0
- Schema:    	0
- Data:      	0
- View:      	0
- Sequence:  	0
- Index:     	0
- Trigger:   	0
- Constraint:	0
- Post:      	0
Retries:	0
circleci@f7116bec80a9:~/issue_1478/mydumper$ ls /tmp/.SPPJU2
ls: cannot access '/tmp/.SPPJU2': No such file or directory
```
We added an inconsistency:
```
circleci@f7116bec80a9:~/issue_1478/mydumper$ vi data/sakila.film_actor.00000.00120.sql.zst
```
Now, the restoration fails and the fifo dir is not removed:
```
circleci@f7116bec80a9:~/issue_1478/mydumper$ ./myloader -u root -o -v 4 -d data/ --serialized-table-creation  -h 172.17.0.4
** Message: 11:47:03.676: Using 4 loader threads
** Message: 11:47:03.680: Config file loaded
** Message: 11:47:03.681: Using /tmp/.EOASU2 as FIFO directory, please remove it if restoration fails
** Message: 11:47:03.722: Connection via default library settings:
	Host: 172.17.0.4
	User: root
** Message: 11:47:03.725: Initializing initialize_worker_schema
** Message: 11:47:03.726: S-Thread 5: Starting import
** Message: 11:47:03.728: Reading metadata: metadata
** Message: 11:47:03.729: Intermediate queue: Sending END job
** Message: 11:47:03.730: Thread 5: restoring create database on `sakila` from sakila-schema-create.sql.zst. Tables 0 of 1 completed
** Message: 11:47:03.743: Intermediate thread ended
** Message: 11:47:03.743: Thread 5: restoring table sakila.film_actor from /home/circleci/project/issue_1478/mydumper/data/sakila.film_actor-schema.sql.zst
** Message: 11:47:03.743: Dropping table or view (if exists) sakila.film_actor
** Message: 11:47:03.744: Intermediate thread: SHUTDOWN
** Message: 11:47:03.750: Thread 5: Creating table sakila.film_actor from content in /home/circleci/project/issue_1478/mydumper/data/sakila.film_actor-schema.sql.zst. On db: sakila
** Message: 11:47:03.759: Thread 5: Table sakila.film_actor created. Tables that pass created stage: 0 of 1
** Message: 11:47:03.759: Schema creation enqueing completed
** Message: 11:47:03.759: Table creation enqueing completed
** Message: 11:47:03.759: S-Thread 5: Import completed
** Message: 11:47:03.760: Thread 1: restoring sakila.film_actor part 3 of 4 from sakila.film_actor.00000.00002.sql.zst | Progress 1 of 4. Tables 0 of 1 completed
** Message: 11:47:03.760: Thread 2: restoring sakila.film_actor part 2 of 4 from sakila.film_actor.00000.00094.sql.zst | Progress 2 of 4. Tables 0 of 1 completed
** Message: 11:47:03.760: Thread 3: restoring sakila.film_actor part 4 of 4 from sakila.film_actor.00000.00120.sql.zst | Progress 3 of 4. Tables 0 of 1 completed
** Message: 11:47:03.761: Thread 4: restoring sakila.film_actor part 1 of 4 from sakila.film_actor.00000.00201.sql.zst | Progress 4 of 4. Tables 0 of 1 completed

** (myloader:4725): WARNING **: 11:47:03.773: Connection 20886 - ERROR 1146: Table 'sakila.film_acto' doesn't exist

** (myloader:4725): CRITICAL **: 11:47:03.773: Connection 20886 - ERROR 1146: Table 'sakila.film_acto' doesn't exist
Trace/breakpoint trap
circleci@f7116bec80a9:~/issue_1478/mydumper$ zstd: /*stdout*\: Broken pipe
zstd: error 70 : Write error : cannot write decoded block : Broken pipe

circleci@f7116bec80a9:~/issue_1478/mydumper$
circleci@f7116bec80a9:~/issue_1478/mydumper$ ls -l /tmp/.EOASU2
total 0
prw-r--r-- 1 circleci circleci 0 Oct  2 11:47 sakila.film_actor.00000.00002.sql
prw-r--r-- 1 circleci circleci 0 Oct  2 11:47 sakila.film_actor.00000.00094.sql
prw-r--r-- 1 circleci circleci 0 Oct  2 11:47 sakila.film_actor.00000.00120.sql
prw-r--r-- 1 circleci circleci 0 Oct  2 11:47 sakila.film_actor.00000.00201.sql
circleci@f7116bec80a9:~/issue_1478/mydumper$ rm -rf /tmp/.EOASU2
```