### PR TITLE
When max rows is != 0 the MIN and MAX will be updated if needed

### DIFF
--- a/src/mydumper_chunks.c
+++ b/src/mydumper_chunks.c
@@ -157,13 +157,9 @@ struct chunk_step_item * initialize_chunk_step_item (MYSQL *conn, struct db_tabl
         gboolean unsign = fields[0].flags & UNSIGNED_FLAG;
         mysql_free_result(minmax);
 
-        // If diff_btwn_max_min > min_chunk_step_size, then there is no need to split the table.
+        // If !(diff_btwn_max_min > min_chunk_step_size), then there is no need to split the table.
         if ( diff_btwn_max_min > dbt->min_chunk_step_size){
           union type type;
-          guint64 min_css = /*dbt->multicolumn ? 1 :*/ dbt->min_chunk_step_size;
-          guint64 max_css = /*dbt->multicolumn ? 1 :*/ dbt->max_chunk_step_size;
-          guint64 starting_css = /*dbt->multicolumn ? 1 :*/ dbt->starting_chunk_step_size;
-          gboolean is_step_fixed_length = (min_css!=0 && min_css == starting_css && max_css == starting_css);
 
           if (unsign){
             type.unsign.min=unmin;
@@ -173,7 +169,8 @@ struct chunk_step_item * initialize_chunk_step_item (MYSQL *conn, struct db_tabl
             type.sign.max=nmax;
           }
 
-          csi = new_integer_step_item( TRUE, prefix, field, unsign, type, 0, is_step_fixed_length, starting_css, min_css, max_css, 0, FALSE, FALSE, NULL, position);
+          gboolean is_step_fixed_length = dbt->min_chunk_step_size!=0 && dbt->min_chunk_step_size == dbt->starting_chunk_step_size && dbt->max_chunk_step_size == dbt->starting_chunk_step_size;
+          csi = new_integer_step_item( TRUE, prefix, field, unsign, type, 0, is_step_fixed_length, dbt->starting_chunk_step_size, dbt->min_chunk_step_size, dbt->max_chunk_step_size, 0, FALSE, FALSE, NULL, position);
 
           if (dbt->multicolumn && csi->position == 0){
             if ((csi->chunk_step->integer_step.is_unsigned && (rows / (csi->chunk_step->integer_step.type.unsign.max - csi->chunk_step->integer_step.type.unsign.min) > (dbt->min_chunk_step_size==0?1000:dbt->min_chunk_step_size))

--- a/src/mydumper_integer_chunks.c
+++ b/src/mydumper_integer_chunks.c
@@ -456,14 +456,14 @@ guint process_integer_chunk_step(struct table_job *tj, struct chunk_step_item *c
 //    m_critical("Thread %d: Trying to process COMPLETED chunk",td->thread_id);
   csi->status = DUMPING_CHUNK;
 
-  if (cs->integer_step.check_max){
-//    g_message("Thread %d: Updating MAX", td->thread_id);
-//    update_integer_max(td->thrconn, tj->dbt, csi);
+  if (cs->integer_step.check_max && tj->dbt->max_chunk_step_size!=0){
+    g_debug("Thread %d: Updating MAX", td->thread_id);
+    update_integer_max(td->thrconn, tj->dbt, csi);
     cs->integer_step.check_max=FALSE;
   }
-  if (cs->integer_step.check_min){
-//    g_message("Thread %d: Updating MIN", td->thread_id);
-//    update_integer_min(td->thrconn, tj->dbt, csi);
+  if (cs->integer_step.check_min && tj->dbt->max_chunk_step_size!=0){
+    g_debug("Thread %d: Updating MIN", td->thread_id);
+    update_integer_min(td->thrconn, tj->dbt, csi);
 //    g_message("thread: %d New MIN: %ld", td->thread_id, tj->chunk_step->integer_step.nmin);
     cs->integer_step.check_min=FALSE;
   }


### PR DESCRIPTION
In the past, we used to update the min and max in integer chunks to remove the empty gaps. When we implemented the automatic setting of --rows, I considered that it was not going to be needed. However, it was pointed out that in cases were you must use --rows for any reason, the updated min and max is desirable to reduce the amount of SELECTs executed.