### PR TITLE
MariaDB CI update

### DIFF
--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -62,10 +62,10 @@ all_vendors[${vendor}_1]="pingcap/tidb"
 
 
 
-list_all_vendors=( "percona57" "percona80" "mariadb1011" "mariadb1006" "mysql80" "mysql84")
 list_mysql_version=( "mysql80" "mysql84" )
 list_percona_version=( "percona57" "percona80" )
 list_mariadb_version=( "mariadb1011" "mariadb1006")
+list_all_vendors=( "${list_mysql_version[@]}" "${list_percona_version[@]}" "${list_mariadb_version[@]}" )
 list_arch=( "arm" "amd" )
 # list_arch=( "amd" )
 declare -A all_arch

--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -44,7 +44,7 @@ all_vendors[${vendor}_4]="mariadbclient"
 
 vendor=mariadb1011
 all_vendors[${vendor}_0]="mariadb1011"
-all_vendors[${vendor}_1]="mariadb:10.11-rc"
+all_vendors[${vendor}_1]="mariadb:10.11"
 all_vendors[${vendor}_2]="mariadb-10.11"
 all_vendors[${vendor}_3]="mariadb"
 all_vendors[${vendor}_4]="mariadbclient"

--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -35,13 +35,6 @@ all_vendors[${vendor}_1]="percona:8"
 all_vendors[${vendor}_3]="perconaserverclient"
 all_vendors[${vendor}_4]="perconaserverclient"
 
-vendor=mariadb1004
-all_vendors[${vendor}_0]="mariadb1004"
-all_vendors[${vendor}_1]="mariadb:10.04-rc"
-all_vendors[${vendor}_2]="mariadb-10.04"
-all_vendors[${vendor}_3]="mariadb"
-all_vendors[${vendor}_4]="mariadbclient"
-
 vendor=mariadb1005
 all_vendors[${vendor}_0]="mariadb1005"
 all_vendors[${vendor}_1]="mariadb:10.05-rc"

--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -62,12 +62,9 @@ all_vendors[${vendor}_1]="pingcap/tidb"
 
 
 
-#list_all_vendors=( "percona57" "percona80" "mariadb1004" "mariadb1005" "mariadb1006" "mariadb1011")
-
 list_all_vendors=( "percona57" "percona80" "mariadb1011" "mariadb1006" "mysql80" "mysql84")
 list_mysql_version=( "mysql80" "mysql84" )
 list_percona_version=( "percona57" "percona80" )
-list_mariadb_version=( "mariadb1004" "mariadb1005" "mariadb1006" "mariadb1011" )
 list_mariadb_version=( "mariadb1011" "mariadb1006")
 list_arch=( "arm" "amd" )
 # list_arch=( "amd" )

--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -35,13 +35,6 @@ all_vendors[${vendor}_1]="percona:8"
 all_vendors[${vendor}_3]="perconaserverclient"
 all_vendors[${vendor}_4]="perconaserverclient"
 
-vendor=mariadb1005
-all_vendors[${vendor}_0]="mariadb1005"
-all_vendors[${vendor}_1]="mariadb:10.05-rc"
-all_vendors[${vendor}_2]="mariadb-10.05"
-all_vendors[${vendor}_3]="mariadb"
-all_vendors[${vendor}_4]="mariadbclient"
-
 vendor=mariadb1006
 all_vendors[${vendor}_0]="mariadb1006"
 all_vendors[${vendor}_1]="mariadb:10.6"


### PR DESCRIPTION
small clean and update 10.11 to the non-RC version.

I'll attempt to add 11.4 in a new PR.

Is testing against our latest from our CI acceptable?

[quay.io/mariadb-foundation/mariadb-devel:verylatest](https://quay.io/repository/mariadb-foundation/mariadb-devel?tab=tags) and/or a temporary repo like https://ci.mariadb.org/main-latest-amd64-ubuntu-2404-deb-autobake.sources for something that stays on the latest.