### PR TITLE
add missing cases for `SERVER_TYPE_DOLT`

### DIFF
--- a/src/mydumper/mydumper_jobs.c
+++ b/src/mydumper/mydumper_jobs.c
@@ -473,7 +473,7 @@ void write_view_definition_into_file(MYSQL *conn, struct db_table *dbt, char *fi
     g_string_append_printf(statement, "%c%s%c int", q, row[0], q);
   }
   g_string_append(statement, "\n) ENGINE=MEMORY");
-  if (get_product() == SERVER_TYPE_PERCONA || get_product() == SERVER_TYPE_MYSQL)
+  if (get_product() == SERVER_TYPE_PERCONA || get_product() == SERVER_TYPE_MYSQL || get_product() == SERVER_TYPE_DOLT)
     g_string_append(statement," ENCRYPTION='N'");
   g_string_append(statement,";\n");
 

--- a/src/mydumper/mydumper_start_dump.c
+++ b/src/mydumper/mydumper_start_dump.c
@@ -383,7 +383,10 @@ MYSQL *create_main_connection() {
   case SERVER_TYPE_CLICKHOUSE:
     data_checksums=FALSE;
     break;
-	default:
+  case SERVER_TYPE_DOLT:
+    set_transaction_isolation_level_repeatable_read(conn);
+    break;
+  default:
     m_critical("Cannot detect server type");
     break;
   }

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -383,7 +383,8 @@ void get_table_info_to_process_from_list(MYSQL *conn, struct configuration *conf
       int is_sequence = 0;
 
       if ((get_product() == SERVER_TYPE_MYSQL ||
-           get_product() == SERVER_TYPE_MARIADB) &&
+           get_product() == SERVER_TYPE_MARIADB ||
+           get_product() == SERVER_TYPE_DOLT) &&
           (row[ecol] == NULL) &&
           (row[ccol] == NULL || !strcmp(row[ccol], "VIEW")))
         is_view = 1;


### PR DESCRIPTION
To support dolt, y'all added a new server type, `SERVER_TYPE_DOLT`, but it is missing from a couple case statements.
This PR fixes that.
Thanks!