### PR TITLE
make .gitignore not match sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ docs/html/searchindex.js
 docs/cmake_install.cmake
 docs/man/
 export-*
-mydumper
-myloader
+/mydumper
+/myloader
 sakila-db*
 data/


### PR DESCRIPTION
Make .gitignore exclude the built binaries at the root mydumper and myloader and not match the source directories src/mydumper and src/myloader, so that other tools such as vscode are able to search within those directories.

In Visual Studio Code (vscode), when the setting “Search: Use Ignore Files” (search.useIgnoreFiles) is on (which is the default), then various tools such as Search: Find in Files (Cmd+Shift+F) and Go to File (Cmd+P) will reuse the `.gitignore` file to determine which files to skip. When the .gitignore file matches files that actually exist, then these commands fail to find matches.