### PR TITLE
Removing pcre.h

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -17,7 +17,6 @@
 
 #include <mysql.h>
 #include <stdio.h>
-#include <pcre.h>
 #include "common_options.h"
 #define MYLOADER_MODE "myloader_mode"
 #define IS_TRX_TABLE 2

--- a/src/connection.c
+++ b/src/connection.c
@@ -18,7 +18,6 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <pcre.h>
 #include <glib.h>
 #include <string.h>
 #include "config.h"

--- a/src/logging.c
+++ b/src/logging.c
@@ -27,7 +27,6 @@
 #include <errno.h>
 #include <time.h>
 #include <zlib.h>
-#include <pcre.h>
 #include <signal.h>
 #include <glib/gstdio.h>
 

--- a/src/mydumper/mydumper_common.c
+++ b/src/mydumper/mydumper_common.c
@@ -23,7 +23,6 @@
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <gio/gio.h>
-#include <pcre.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -15,7 +15,6 @@
     Authors:        Andrew Hutchings, MariaDB Foundation (andrew at mariadb dot org)
 */
 
-#include <pcre.h>
 #include <glib.h>
 #include <string.h>
 #include "server_detect.h"

--- a/src/set_verbose.c
+++ b/src/set_verbose.c
@@ -27,7 +27,6 @@
 #include <errno.h>
 #include <time.h>
 //#include <zlib.h>
-#include <pcre.h>
 #include <signal.h>
 #include <glib/gstdio.h>
 #include "logging.h"


### PR DESCRIPTION
Some references to pcre.h were left in the code. This PR removes all of them. BTW we are using pcre2.h now.