### PR TITLE
Explicitly state the minimum possible thread number

### DIFF
--- a/src/common_options.c
+++ b/src/common_options.c
@@ -68,7 +68,7 @@ guint throttle_value=0;
 
 GOptionEntry common_entries[] = {
     {"threads", 't', 0, G_OPTION_ARG_INT, &num_threads,
-      "Number of threads to use, 0 means to use number of CPUs. Default: 4, Minumum: 2", NULL},
+      "Number of threads to use, 0 means to use number of CPUs. Default: 4, Minimum: 2", NULL},
     {"version", 'V', 0, G_OPTION_ARG_NONE, &program_version,
       "Show the program version and exit", NULL},
     {"verbose", 'v', 0, G_OPTION_ARG_INT, &verbose,


### PR DESCRIPTION
I tried to set max_threads to 1 because mydumper dumping too fast.
Until I enabled debug logging I did not see that mydumper is still using 2 threads.

Based on https://github.com/mydumper/mydumper/blob/5dae2cdf51de0ed84754e68f9cb6010b71916948/src/common.c#L770

This should be the correct place to fix it :D

https://github.com/mydumper/mydumper_docs/pull/8
