### PR TITLE
Implementing --hex-blob correctly and adding CHARACTER_SET_RESULTS to conf

### DIFF
--- a/mydumper.cnf
+++ b/mydumper.cnf
@@ -17,6 +17,7 @@
 # wait_timeout = 300
 # sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'
 # sql_mode='ANSI_QUOTES';
+CHARACTER_SET_RESULTS = NULL
 
 [myloader_global_variables]
 # The global variables changed in this section are rolled back after execution unless QUIT signal is sent.


### PR DESCRIPTION
This is the first time that we add a change in the session variable on mydumper. We added:
```
CHARACTER_SET_RESULTS = NULL
```
to `[mydumper_session_variables]` which allow us to identified correctly when a column is BINARY or not:
```
unsigned int charsetnr

An ID number that indicates the character set/collation pair for the field.

Normally, character values in result sets are converted to the character set indicated by the [character_set_results](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_character_set_results) system variable. In this case, charsetnr corresponds to the character set indicated by that variable. Character set conversion can be suppressed by setting [character_set_results](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_character_set_results) to NULL. In this case, charsetnr corresponds to the character set of the original table column or expression. See also [Connection Character Sets and Collations](https://dev.mysql.com/doc/refman/8.0/en/charset-connection.html).

To distinguish between binary and nonbinary data for string data types, check whether the charsetnr value is 63. If so, the character set is binary, which indicates binary rather than nonbinary data. This enables you to distinguish [BINARY](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html) from [CHAR](https://dev.mysql.com/doc/refman/8.0/en/char.html), [VARBINARY](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html) from [VARCHAR](https://dev.mysql.com/doc/refman/8.0/en/char.html), and the [BLOB](https://dev.mysql.com/doc/refman/8.0/en/blob.html) types from the [TEXT](https://dev.mysql.com/doc/refman/8.0/en/blob.html) types.
```
Reference: https://dev.mysql.com/doc/c-api/8.0/en/c-api-data-structures.html