### PR TITLE
Adding --server-version to avoid automatic server detection

### DIFF
--- a/src/common_options.c
+++ b/src/common_options.c
@@ -65,6 +65,8 @@ gint source_data=0;
 gchar *throttle_variable=NULL;
 guint throttle_value=0;
 
+gchar *server_version_arg=NULL;
+
 GOptionEntry common_entries[] = {
     {"threads", 't', 0, G_OPTION_ARG_INT, &num_threads,
       "Number of threads to use, 0 means to use number of CPUs. Default: 4, Minimum: 2", NULL},
@@ -85,6 +87,8 @@ GOptionEntry common_entries[] = {
       "Instruct the proper commands to execute depending where are configuring the replication. Options: TRADITIONAL, AWS", NULL},
     {"optimize-keys-engines", 0, 0, G_OPTION_ARG_CALLBACK , &common_arguments_callback,
       "List of engines that will be used to split the create table statement into multiple stages if possible. Default: InnoDB,ROCKSDB", NULL},
+    {"server-version", 0, 0, G_OPTION_ARG_STRING, &server_version_arg,
+      "Set the server version avoid automatic detection", NULL},
     {"source-data", 0, 0, G_OPTION_ARG_INT, &source_data, 
       "It will include the options in the metadata file, to allow myloader to establish replication", NULL},
     {"throttle", 0, G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK, &common_arguments_callback,

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -37,6 +37,8 @@ const gchar *change_replication_source=NULL;
 const gchar *case_sensitive_prefix=NULL;
 const gchar *case_sensitive_suffix=NULL;
 
+extern gchar *server_version_arg;
+
 int get_product(){
   return product;
 }
@@ -72,32 +74,45 @@ gboolean server_support_tablespaces(){
 }
 
 static
+void detect_product(gchar *_ascii_version_comment, gchar *_ascii_version){
+  gchar *ascii_version=_ascii_version?g_ascii_strdown(_ascii_version,-1):NULL;
+  gchar *ascii_version_comment=_ascii_version_comment?g_ascii_strdown(_ascii_version_comment,-1):NULL;
+
+  if ( (ascii_version && g_strstr_len(ascii_version, -1, "percona") ) || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "percona"))){
+    product = SERVER_TYPE_PERCONA;
+  }else
+  if ( (ascii_version && g_strstr_len(ascii_version, -1, "mariadb")) || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "mariadb"))){
+    product = SERVER_TYPE_MARIADB;
+  }else
+  if ( (ascii_version && g_strstr_len(ascii_version, -1, "tidb"))    || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "tidb"))){
+    product = SERVER_TYPE_TIDB;
+  }else
+  if ( (ascii_version && g_strstr_len(ascii_version, -1, "dolt"))    || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "dolt"))){
+    product = SERVER_TYPE_DOLT;
+  }else
+  if ( (ascii_version && g_strstr_len(ascii_version, -1, "mysql"))   || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "mysql")) || 
+       (ascii_version && g_strstr_len(ascii_version, -1, "source"))  || (ascii_version_comment && g_strstr_len(ascii_version_comment, -1, "source"))){
+    product = SERVER_TYPE_MYSQL;
+  }
+}
+
+static
+void detect_version(gchar ** sver){
+  major=strtol(sver[0], NULL, 10);
+  secondary=strtol(sver[1], NULL, 10);
+  revision=strtol(sver[2], NULL, 10);
+}
+
+static
 void detect_server_version(MYSQL * conn) {
   struct M_ROW *mr = m_store_result_row(conn, "SELECT @@version_comment, @@version",m_warning, m_message, "Not able to determine database version", NULL);
 //  struct M_ROW *mr = m_store_result_row(conn, "SELECT 'Source distribution', '8.0.40-azure' ",m_warning, m_message, "Not able to determine database version", NULL);
 
-  gchar *ascii_version=NULL;
   gchar *ascii_version_comment=NULL;
 
   if (mr->row){
     ascii_version_comment=g_ascii_strdown(mr->row[0],-1);
-    ascii_version        =g_ascii_strdown(mr->row[1],-1);
-
-    if (g_strstr_len(ascii_version, -1, "percona") || g_strstr_len(ascii_version_comment, -1, "percona")){
-      product = SERVER_TYPE_PERCONA;
-    }else
-    if (g_strstr_len(ascii_version, -1, "mariadb") || g_strstr_len(ascii_version_comment, -1, "mariadb")){
-      product = SERVER_TYPE_MARIADB;
-    }else
-    if (g_strstr_len(ascii_version, -1, "tidb") || g_strstr_len(ascii_version_comment, -1, "tidb")){
-      product = SERVER_TYPE_TIDB;
-    }else
-    if (g_strstr_len(ascii_version, -1, "dolt") || g_strstr_len(ascii_version_comment, -1, "dolt")){
-      product = SERVER_TYPE_DOLT;
-    }else
-    if (g_strstr_len(ascii_version, -1, "mysql") || g_strstr_len(ascii_version_comment, -1, "mysql") || g_strstr_len(ascii_version, -1, "source") || g_strstr_len(ascii_version_comment, -1, "source")){
-      product = SERVER_TYPE_MYSQL;    
-    }
+    detect_product(mr->row[0],mr->row[1]);
   }
 
 	gchar ** sver=NULL;
@@ -105,24 +120,23 @@ void detect_server_version(MYSQL * conn) {
     m_store_result_row_free(mr);
     mr = m_store_result_row(conn, "SELECT value FROM system.build_options where name='VERSION_FULL' LIMIT 1",m_warning,m_message,"Not able to determine database version", NULL);
     if (mr->row){
-      ascii_version=g_ascii_strdown(mr->row[0],-1);
+      gchar * ascii_version=g_ascii_strdown(mr->row[0],-1);
       gchar ** psver=g_strsplit(ascii_version," ",2);
       if (g_strstr_len(ascii_version, -1, "clickhouse") || g_strstr_len(ascii_version_comment, -1, "clickhouse")){
         product = SERVER_TYPE_CLICKHOUSE;
       sver=g_strsplit(psver[1],".",4);
       }
       g_strfreev(psver);
-		}else
+      g_free(ascii_version);
+	}else
       sver=g_strsplit("0.0.0",".",3);
 	}else
     sver=g_strsplit(mr->row[1],".",3);
   m_store_result_row_free(mr);
 
-  major=strtol(sver[0], NULL, 10);
-  secondary=strtol(sver[1], NULL, 10);
-  revision=strtol(sver[2], NULL, 10);
+  detect_version(sver);
+
   g_strfreev(sver);
-  g_free(ascii_version);
   g_free(ascii_version_comment);
 }
 
@@ -214,7 +228,17 @@ void detect_replica() {
 }
 
 void server_detect(MYSQL * conn){
-  detect_server_version(conn);
+  if (server_version_arg){
+    gchar ** _product=g_strsplit(server_version_arg,"-",2);
+    detect_product(_product[0],_product[1]);
+    if (_product[1]){
+      gchar ** sver=g_strsplit(_product[1],".",3);
+      detect_version(sver);
+      g_strfreev(sver);
+    }
+    g_strfreev(_product);
+  }else
+    detect_server_version(conn);
   detect_lower_case_table_names(conn);
   detect_replica();  
 }


### PR DESCRIPTION
MyDumper detected the product and version of the servers that it was connecting automatically. However, this might be causing issue when some specifics products were being used, like AWS, and others. 
With --server-version you will be able to set the product and version like this: "<PRODUCT> - <VERSION>" , where product will be the know products: MySQL, Percona, MariaDB, Source, Dolt and TiDB and the VERSION will be 3 numbers delimited by dots, like: 5.7.30, 8.0.24, 10.6.34, etc