### PR TITLE
Adjust chunk size dynamically based on fragmentation

### DIFF
--- a/src/common_options.c
+++ b/src/common_options.c
@@ -57,7 +57,7 @@ gchar identifier_quote_character=BACKTICK;
 const char *identifier_quote_character_str= "`";
 
 gboolean schema_sequence_fix = FALSE;
-guint max_threads_per_table= G_MAXUINT;
+guint max_threads_per_table= 4;
 
 guint source_control_command = TRADITIONAL;
 gint source_data=0;

--- a/src/mydumper/mydumper_arguments.c
+++ b/src/mydumper/mydumper_arguments.c
@@ -29,6 +29,7 @@
 
 extern guint64 min_integer_chunk_step_size;
 extern guint64 max_integer_chunk_step_size;
+extern guint max_time_per_select;
 
 enum sync_thread_lock_mode sync_thread_lock_mode=AUTO;
 const gchar *compress_method=NULL;
@@ -268,6 +269,8 @@ static GOptionEntry daemon_entries[] = {
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 
 static GOptionEntry chunks_entries[] = {
+    {"max-time-per-select", 0, 0, G_OPTION_ARG_INT, &max_time_per_select,
+      "Maximum amount of seconds that a select should take. Default: 2", NULL},
     {"max-threads-per-table", 0, 0, G_OPTION_ARG_INT, &max_threads_per_table,
       "Maximum number of threads per table to use", NULL},
     {"use-single-column", 0, 0, G_OPTION_ARG_NONE, &use_single_column, 

--- a/src/mydumper/mydumper_chunks.c
+++ b/src/mydumper/mydumper_chunks.c
@@ -148,13 +148,13 @@ struct chunk_step_item * initialize_chunk_step_item (MYSQL *conn, struct db_tabl
           _starting_chunk_step_size= dbt->max_chunk_step_size!=0 ?
                                              (rows/num_threads>dbt->max_chunk_step_size?
                                                dbt->max_chunk_step_size:
-                                               rows/num_threads):
-//                                               rows/((log(percentage_of_fragmentation )+1)*num_threads)):
-                                                rows/num_threads;
-//                                             rows/((log(percentage_of_fragmentation )+1)*num_threads);
+ //                                              rows/num_threads):
+                                               rows/((log(percentage_of_fragmentation )+1)*num_threads)):
+ //                                               rows/num_threads;
+                                             rows/((log(percentage_of_fragmentation )+1)*num_threads);
           if (dbt->max_chunk_step_size==0)
-            max_chunk_step_size=rows/num_threads;
-            //            max_chunk_step_size=rows/((log(percentage_of_fragmentation )+1)*num_threads);
+//            max_chunk_step_size=rows/num_threads;
+            max_chunk_step_size=diff_btwn_max_min/((log(percentage_of_fragmentation )+1)*num_threads);
         }
         if (_starting_chunk_step_size < dbt->min_chunk_step_size)
           _starting_chunk_step_size=dbt->min_chunk_step_size;

--- a/src/mydumper/mydumper_create_jobs.c
+++ b/src/mydumper/mydumper_create_jobs.c
@@ -221,13 +221,13 @@ struct table_job * new_table_job(struct db_table *dbt, char *partition, guint64 
   tj->part=part;
   tj->sub_part = 0;
   tj->rows=g_new0(struct table_job_file, 1);
-  tj->rows->file = 0;
+  tj->rows->file = -1;
   tj->rows->filename = NULL;
   if (output_format==SQL_INSERT)
 		tj->sql=NULL;
 	else{
 		tj->sql=g_new0(struct table_job_file, 1);
-    tj->sql->file = 0;
+    tj->sql->file = -1;
     tj->sql->filename = NULL;
   }
   tj->exec_out_filename = NULL;
@@ -243,14 +243,16 @@ struct table_job * new_table_job(struct db_table *dbt, char *partition, guint64 
 }
 
 void free_table_job(struct table_job *tj){
-  if (tj->sql){
-    m_close(tj->td->thread_id, tj->sql->file, tj->sql->filename, tj->filesize, tj->dbt);
-    tj->sql->file=0;
+  if (tj->sql && tj->sql->file >= 0){
+    if (tj->sql->file >= 0)
+      m_close(tj->td->thread_id, tj->sql->file, tj->sql->filename, tj->filesize, tj->dbt);
+    tj->sql->file=-1;
     tj->sql=NULL;
   }
   if (tj->rows){
-    m_close(tj->td->thread_id, tj->rows->file, tj->rows->filename, tj->filesize, tj->dbt);
-    tj->rows->file=0;
+    if (tj->rows->file >= 0)
+      m_close(tj->td->thread_id, tj->rows->file, tj->rows->filename, tj->filesize, tj->dbt);
+    tj->rows->file=-1;
     tj->rows=NULL;
   }
 

--- a/src/mydumper/mydumper_file_handler.c
+++ b/src/mydumper/mydumper_file_handler.c
@@ -45,33 +45,30 @@ static gboolean is_pipe=FALSE;
 int m_open_file(char **filename, const char *type ){
   (void) type;
   int fd=open(*filename, O_CREAT|O_WRONLY|O_TRUNC, 0660 );
-  if (fd<=0){
-    g_critical("Couldn't open file(%s): %s", *filename, strerror(errno));
-//    fd=m_open_file(filename,type);
-  }else
-    g_message("Open file: %s", *filename);
+  if (fd<0)
+    m_critical("Couldn't open file(%s): %s", *filename, strerror(errno));
   return fd;
 }
 
 int m_close_file(guint thread_id, int file, gchar *filename, guint64 size, struct db_table * dbt){
-  if (file > 0){
-  g_message("Closing file(%d): %s", file, filename);
-  int r=close(file);
-  if (size > 0){
-    if (exec_command)  exec_queue_push(dbt, g_strdup(filename));
-    else if (stream) stream_queue_push(dbt, g_strdup(filename));
-  }else if (!build_empty_files){
-    if (filename){
-      if (remove(filename)) {
-        g_warning("Thread %d: Failed to remove empty file : %s", thread_id, filename);
-      }else{
-        g_debug("Thread %d: File removed: %s", thread_id, filename);
+  if (file >= 0){
+    trace("Closing file(%d): %s", file, filename);
+    int r=close(file);
+    if (size > 0){
+      if (exec_command)  exec_queue_push(dbt, g_strdup(filename));
+      else if (stream) stream_queue_push(dbt, g_strdup(filename));
+    }else if (!build_empty_files){
+      if (filename){
+        if (remove(filename)) {
+          g_warning("Thread %d: Failed to remove empty file : %s", thread_id, filename);
+        }else{
+          g_debug("Thread %d: File removed: %s", thread_id, filename);
+        }
       }
+      return r;
     }
-    return r;
-  }
   }else{
-    g_warning("Closing 0 ? are you crazy?"); 
+    m_critical("Trying to close %s with fd: %d", filename, file); 
   }
   return 0;
 }

--- a/src/mydumper/mydumper_file_handler.c
+++ b/src/mydumper/mydumper_file_handler.c
@@ -44,22 +44,36 @@ static gboolean is_pipe=FALSE;
 // FILE open/close without pipe
 int m_open_file(char **filename, const char *type ){
   (void) type;
-  return open(*filename, O_CREAT|O_WRONLY|O_TRUNC, 0660 );
+  int fd=open(*filename, O_CREAT|O_WRONLY|O_TRUNC, 0660 );
+  if (fd<=0){
+    g_critical("Couldn't open file(%s): %s", *filename, strerror(errno));
+//    fd=m_open_file(filename,type);
+  }else
+    g_message("Open file: %s", *filename);
+  return fd;
 }
 
 int m_close_file(guint thread_id, int file, gchar *filename, guint64 size, struct db_table * dbt){
+  if (file > 0){
+  g_message("Closing file(%d): %s", file, filename);
   int r=close(file);
   if (size > 0){
     if (exec_command)  exec_queue_push(dbt, g_strdup(filename));
     else if (stream) stream_queue_push(dbt, g_strdup(filename));
   }else if (!build_empty_files){
-    if (remove(filename)) {
-      g_warning("Thread %d: Failed to remove empty file : %s", thread_id, filename);
-    }else{
-      g_debug("Thread %d: File removed: %s", thread_id, filename);
+    if (filename){
+      if (remove(filename)) {
+        g_warning("Thread %d: Failed to remove empty file : %s", thread_id, filename);
+      }else{
+        g_debug("Thread %d: File removed: %s", thread_id, filename);
+      }
     }
+    return r;
   }
-  return r;
+  }else{
+    g_warning("Closing 0 ? are you crazy?"); 
+  }
+  return 0;
 }
 
 // PIPE related functions 

--- a/src/mydumper/mydumper_integer_chunks.c
+++ b/src/mydumper/mydumper_integer_chunks.c
@@ -60,14 +60,12 @@ void initialize_integer_step(union chunk_step *cs, gboolean is_unsigned, union t
   cs->integer_step.max_chunk_step_size = max_css;
   if (cs->integer_step.is_unsigned){
     cs->integer_step.type.unsign.min = type.unsign.min;
-    cs->integer_step.type.unsign.initial_min = cs->integer_step.type.unsign.min;
     cs->integer_step.type.unsign.cursor = cs->integer_step.type.unsign.min;
     cs->integer_step.type.unsign.max = type.unsign.max;
     cs->integer_step.step = step;
     cs->integer_step.estimated_remaining_steps=(cs->integer_step.type.unsign.max - cs->integer_step.type.unsign.min) / cs->integer_step.step;
   }else{
     cs->integer_step.type.sign.min = type.sign.min;
-    cs->integer_step.type.sign.initial_min = cs->integer_step.type.sign.min;
     cs->integer_step.type.sign.cursor = cs->integer_step.type.sign.min;
     cs->integer_step.type.sign.max = type.sign.max;
     cs->integer_step.step = step;

--- a/src/mydumper/mydumper_integer_chunks.c
+++ b/src/mydumper/mydumper_integer_chunks.c
@@ -541,21 +541,10 @@ guint process_integer_chunk_step(struct table_job *tj, struct chunk_step_item *c
       trace("Thread %d: New MIN: %ld", td->thread_id, cs->integer_step.type.sign.min);
     cs->integer_step.check_min=FALSE;
   }
-//gboolean b=TRUE;
   if (!c_min && !c_max){
-    g_message("Thread %d: both min and max doesn't exists", td->thread_id);
     trace("Thread %d: both min and max doesn't exists", td->thread_id);
-//    b=FALSE;
-    if (cs->integer_step.is_unsigned){
-      cs->integer_step.type.unsign.cursor=cs->integer_step.type.unsign.min;
-      cs->integer_step.type.unsign.min++;
-    }else{
-      cs->integer_step.type.sign.cursor=cs->integer_step.type.sign.min;
-      cs->integer_step.type.sign.min++;
-    }
-    g_mutex_unlock(csi->mutex);  
-    goto update_min;
-//    goto end_process; 
+    close_files(tj);
+    goto end_process; 
   }
 
 
@@ -784,7 +773,7 @@ update_min:
 
 //  g_message("Thread %d: integer_step.type.sign.cursor: %"G_GINT64_FORMAT"  | integer_step.type.sign.min %"G_GINT64_FORMAT"  | cs->integer_step.type.sign.max : %"G_GINT64_FORMAT" | cs->integer_step.step %ld", td->thread_id, cs->integer_step.type.sign.cursor, cs->integer_step.type.sign.min, cs->integer_step.type.sign.max, cs->integer_step.step);
 
-//end_process:
+end_process:
 
   if (csi->position==0)
     csi->multicolumn=tj->dbt->multicolumn;

--- a/src/mydumper/mydumper_integer_chunks.h
+++ b/src/mydumper/mydumper_integer_chunks.h
@@ -27,14 +27,12 @@
 #include "mydumper_chunks.h"
 
 struct unsigned_int{
-  guint64 initial_min;
   guint64 min;
   guint64 cursor;
   guint64 max;
 };
 
 struct signed_int{
-  gint64 initial_min;
   gint64 min;
   gint64 cursor;
   gint64 max;

--- a/src/mydumper/mydumper_integer_chunks.h
+++ b/src/mydumper/mydumper_integer_chunks.h
@@ -27,12 +27,14 @@
 #include "mydumper_chunks.h"
 
 struct unsigned_int{
+  guint64 initial_min;
   guint64 min;
   guint64 cursor;
   guint64 max;
 };
 
 struct signed_int{
+  gint64 initial_min;
   gint64 min;
   gint64 cursor;
   gint64 max;
@@ -53,11 +55,12 @@ struct integer_step {
   guint64 estimated_remaining_steps;
   gboolean check_max;
   gboolean check_min;
+  guint64 rows_in_explain;
 };
 #endif 
 
 guint64 gint64_abs(gint64 a);
-struct chunk_step_item *new_integer_step_item(gboolean include_null, GString *prefix, gchar *field, gboolean is_unsigned, union type type, guint deep, gboolean is_step_fixed_length, guint64 step, guint64 min_css, guint64 max_css, guint64 number, gboolean check_min, gboolean check_max, struct chunk_step_item * next, guint position, gboolean multicolumn);
+struct chunk_step_item *new_integer_step_item(gboolean include_null, GString *prefix, gchar *field, gboolean is_unsigned, union type type, guint deep, gboolean is_step_fixed_length, guint64 step, guint64 min_css, guint64 max_css, guint64 number, gboolean check_min, gboolean check_max, struct chunk_step_item * next, guint position, gboolean multicolumn, guint64 rows_in_explain);
 void free_integer_step(union chunk_step * cs);
 struct chunk_step_item *get_next_integer_chunk(struct db_table *dbt);
 void process_integer_chunk(struct table_job *tj, struct chunk_step_item *csi);

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -195,67 +195,6 @@ void finalize_working_thread(){
   g_free(threads);
   finalize_table();
 }
-/*
-static
-void get_primary_key(MYSQL *conn, struct db_table * dbt, struct configuration *conf){
-  MYSQL_RES *indexes = NULL;
-  MYSQL_ROW row;
-  dbt->primary_key=NULL;
-  // first have to pick index, in future should be able to preset in
-  //    * configuration too 
-  gchar *query = g_strdup_printf("SHOW INDEX FROM %s%s%s.%s%s%s",
-                        identifier_quote_character_str, dbt->database->name, identifier_quote_character_str, identifier_quote_character_str, dbt->table, identifier_quote_character_str);
-  indexes = m_store_result(conn, query, m_warning, "Failed to execute SHOW INDEX over %s", dbt->database->name);
-  g_free(query);
-
-  if (indexes){
-    while ((row = mysql_fetch_row(indexes))) {
-      if (!strcmp(row[2], "PRIMARY") ) {
-        // Pick first column in PK, cardinality doesn't matter
-        dbt->primary_key=g_list_append(dbt->primary_key,g_strdup(row[4]));
-      }
-    }
-    if (dbt->primary_key)
-      goto cleanup;
-
-    // If no PK found, try using first UNIQUE index
-    mysql_data_seek(indexes, 0);
-    while ((row = mysql_fetch_row(indexes))) {
-      if (!strcmp(row[1], "0")) {
-        // Again, first column of any unique index 
-        dbt->primary_key=g_list_append(dbt->primary_key,g_strdup(row[4]));
-      }
-    }
-
-    if (dbt->primary_key)
-      goto cleanup;
-
-    // Still unlucky? Pick any high-cardinality index 
-    if (!dbt->primary_key && conf->use_any_index) {
-      guint64 max_cardinality = 0;
-      guint64 cardinality = 0;
-      gchar *field=NULL;
-      mysql_data_seek(indexes, 0);
-      while ((row = mysql_fetch_row(indexes))) {
-        if (!strcmp(row[3], "1")) {
-          if (row[6])
-            cardinality = strtoul(row[6], NULL, 10);
-          if (cardinality > max_cardinality) {
-            field = g_strdup(row[4]);
-            max_cardinality = cardinality;
-          }
-        }
-      }
-      if (field)
-        dbt->primary_key=g_list_append(dbt->primary_key,field);
-    }
-  }
-
-cleanup:
-  if (indexes)
-    mysql_free_result(indexes);
-}
-*/
 
 void thd_JOB_DUMP_ALL_DATABASES( struct thread_data *td, struct job *job){
   // TODO: This should be in a job as needs to be done by a thread.
@@ -373,10 +312,7 @@ void get_table_info_to_process_from_list(MYSQL *conn, struct configuration *conf
     g_async_queue_push(conf->db_ready,GINT_TO_POINTER(1));
 //    g_rec_mutex_unlock(ready_database_dump_mutex);
   }
-
 }
-
-
 
 void thd_JOB_DUMP_TABLE_LIST(struct thread_data *td, struct job *job){
   struct dump_table_list_job * dtlj = (struct dump_table_list_job *)job->job_data;

--- a/src/mydumper/mydumper_write.c
+++ b/src/mydumper/mydumper_write.c
@@ -72,7 +72,7 @@ gboolean hex_blob = FALSE;
 
 gboolean update_files_on_table_job(struct table_job *tj)
 {
-  if (tj->rows->file == 0){
+  if (tj->rows->file < 0){
     tj->rows->filename = build_rows_filename(tj->dbt->database->filename, tj->dbt->table_filename, tj->part, tj->sub_part);
     tj->rows->file = m_open(&(tj->rows->filename),"w");
     trace("Thread %d: Filename assigned(%d): %s", tj->td->thread_id, tj->rows->file, tj->rows->filename);
@@ -660,14 +660,11 @@ void update_dbt_rows(struct db_table * dbt, guint64 num_rows){
 }
 
 void close_file(struct table_job * tj, struct table_job_file *tjf){
-  if (tjf->file!=0){
+  if (tjf->file >= 0){
     m_close(tj->td->thread_id, tjf->file, tjf->filename, 1, tj->dbt);
-    tjf->file=0;
+    tjf->file=-1;
     g_free(tjf->filename);
     tjf->filename=NULL;
-  }else{
-    g_message("Not closing file: %d %s", tjf->file, tjf->filename);
-  
   }
 }
 
@@ -739,7 +736,7 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       }
 	  	break;
     case CLICKHOUSE:
-      if (tj->rows->file == 0){
+      if (tj->rows->file < 0){
         update_files_on_table_job(tj);
       }
 			if (dbt->load_data_suffix==NULL){
@@ -761,7 +758,7 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       g_string_append(tj->td->thread_data_buffers.statement, dbt->insert_statement->str);
       break;
 		case SQL_INSERT:
-      if (tj->rows->file == 0){
+      if (tj->rows->file < 0){
         update_files_on_table_job(tj);
   		}
       if (dbt->insert_statement==NULL){

--- a/src/mydumper/mydumper_write.c
+++ b/src/mydumper/mydumper_write.c
@@ -75,10 +75,12 @@ gboolean update_files_on_table_job(struct table_job *tj)
   if (tj->rows->file == 0){
     tj->rows->filename = build_rows_filename(tj->dbt->database->filename, tj->dbt->table_filename, tj->part, tj->sub_part);
     tj->rows->file = m_open(&(tj->rows->filename),"w");
+    trace("Thread %d: Filename assigned(%d): %s", tj->td->thread_id, tj->rows->file, tj->rows->filename);
 
     if (tj->sql){
       tj->sql->filename =build_sql_filename(tj->dbt->database->filename, tj->dbt->table_filename, tj->part, tj->sub_part);
       tj->sql->file = m_open(&(tj->sql->filename),"w");
+      trace("Thread %d: Filename assigned: %s", tj->td->thread_id, tj->sql->filename);
       return TRUE;
     }
   }
@@ -390,7 +392,7 @@ gboolean real_write_data(int file, float *filesize, GString *data) {
   while (written < data->len) {
     r=write(file, data->str + written, data->len - written);
     if (r < 0) {
-      g_critical("Couldn't write data to a file: %s", strerror(errno));
+      g_critical("Couldn't write data to a file(%d): %s", file, strerror(errno));
       errors++;
       return FALSE;
     }
@@ -663,6 +665,9 @@ void close_file(struct table_job * tj, struct table_job_file *tjf){
     tjf->file=0;
     g_free(tjf->filename);
     tjf->filename=NULL;
+  }else{
+    g_message("Not closing file: %d %s", tjf->file, tjf->filename);
+  
   }
 }
 
@@ -679,6 +684,7 @@ void close_files(struct table_job * tj){
   close_file(tj, tj->rows);
 }
 
+static
 void reopen_files(struct table_job * tj){
   close_files(tj);
   switch (output_format){
@@ -773,7 +779,11 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
   message_dumping_data(tj);
 
   GDateTime *from = g_date_time_new_now_local();
+  GDateTime *to = NULL;
+  GTimeSpan diff=0;
 	while ((row = mysql_fetch_row(result))) {
+// Uncomment next line if you need to simulate a slow read which is useful when calculate the chunk size
+//    g_usleep(1);
     lengths = mysql_fetch_lengths(result);
     num_rows++;
     // prepare row into statement_row
@@ -789,9 +799,11 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       }
       g_string_append(tj->td->thread_data_buffers.statement, statement_terminated_by);
       if (!write_statement(tj->rows->file, &(tj->filesize), tj->td->thread_data_buffers.statement, dbt)) {
+        g_critical("Fail to write on %s", tj->rows->filename);
         return;
       }
 			update_dbt_rows(dbt, num_rows);
+      tj->num_rows_of_last_run+=num_rows;
 			num_rows=0;
 			num_rows_st=0;
 			tj->st_in_file++;
@@ -799,8 +811,8 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       if (output_format == SQL_INSERT || output_format == CLICKHOUSE){
 				g_string_append(tj->td->thread_data_buffers.statement, dbt->insert_statement->str);
 			}
-      GDateTime *to = g_date_time_new_now_local();
-      GTimeSpan diff=g_date_time_difference(to,from)/G_TIME_SPAN_SECOND;
+      to = g_date_time_new_now_local();
+      diff=g_date_time_difference(to,from)/G_TIME_SPAN_SECOND;
       if (diff > 4){
         g_date_time_unref(from);
         from=to;
@@ -834,15 +846,16 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
     g_string_set_size(tj->td->thread_data_buffers.row, 0);
   }
   update_dbt_rows(dbt, num_rows);
+  tj->num_rows_of_last_run+=num_rows;
   if (num_rows_st > 0 && tj->td->thread_data_buffers.statement->len > 0){
     if (output_format == SQL_INSERT || output_format == CLICKHOUSE)
 			g_string_append(tj->td->thread_data_buffers.statement, statement_terminated_by);
     if (!write_statement(tj->rows->file, &(tj->filesize), tj->td->thread_data_buffers.statement, dbt)) {
+      g_critical("Fail to write on %s", tj->rows->filename);
       return;
     }
 		tj->st_in_file++;
   }
-  tj->num_rows_of_last_run=num_rows;
 //  g_string_free(statement, TRUE);
 //  g_string_free(escaped, TRUE);
 //  g_string_free(statement_row, TRUE);	
@@ -856,6 +869,8 @@ void write_table_job_into_file(struct table_job * tj){
 
 //  if (throttle_time)
   g_usleep(throttle_time);
+
+  tj->num_rows_of_last_run=0;
 
   /* Ghm, not sure if this should be statement_size - but default isn't too big
    * for now */

--- a/src/mydumper/mydumper_write.h
+++ b/src/mydumper/mydumper_write.h
@@ -30,5 +30,4 @@ void initialize_write();
 void finalize_write();
 void write_table_job_into_file(struct table_job *tj);
 gboolean write_data(int file, GString *data);
-void reopen_files(struct table_job * tj);
 void close_files(struct table_job * tj);


### PR DESCRIPTION
We change the default of max_threads_per_table to 4.
We added the option on mydumper --max-time-per-select which is the targeting of the amount of time the selects will take. 
We added percentage_of_fragmentation to calculate this: diff_btwn_max_min / rows, which is the (MAX - MIN) / rows.
And we are using the log(percentage_of_fragmentation) to determine the best max step size and the starting step size.
Max is based on the diff_btwn_max_min which could be much larger number than rows. 
The starting step size is based on the rows. 
We also take into the amount of threads to perform the calculations.
