### PR TITLE
Deduplicate partition name in case of subpartitions

### DIFF
--- a/src/mydumper/mydumper_partition_chunks.c
+++ b/src/mydumper/mydumper_partition_chunks.c
@@ -118,7 +118,7 @@ struct chunk_step_item *get_next_partition_chunk(struct db_table *dbt){
 
 GList * get_partitions_for_table(MYSQL *conn, struct db_table *dbt){
 
-  gchar *query = g_strdup_printf("select PARTITION_NAME from information_schema.PARTITIONS where PARTITION_NAME is not null and TABLE_SCHEMA='%s' and TABLE_NAME='%s'", dbt->database->source_database, dbt->table);
+  gchar *query = g_strdup_printf("select DISTINCT PARTITION_NAME from information_schema.PARTITIONS where PARTITION_NAME is not null and TABLE_SCHEMA='%s' and TABLE_NAME='%s'", dbt->database->source_database, dbt->table);
   MYSQL_RES *res=m_store_result(conn,query, NULL,"Partitioning is not supported", NULL);
   g_free(query);
 


### PR DESCRIPTION
When I enable `--split-partitions` on subpartitioned tables, `get_partitions_for_table` in `src/mydumper/mydumper_partition_chunks.c` lists a duplicate partition name for every subpartition, leading to duplicate work, and a dump which we can't load back because of duplicate entries. The duplicate results of this query looks like this:
<img width="237" height="286" alt="image" src="https://github.com/user-attachments/assets/f7bd9592-d67a-4786-850c-1ccd1b325442" />


In this PR, I'm adding a DISTINCT on the partition query to solve this problem. Do I need to do anything else?


### More context
In my case, the table's dump size goes from 700 MB to 40 GB when you enable split partitions, and I get this error when I try to load the dump to a new database:
```
ERROR 1062: Duplicate entry '12-1-2023-08-27' for key 'itemscenariometrics.PRIMARY'
```

I checked the data directly and there were lots of duplicates(same PK):
```
# $F is one of the .sql.zst files
> zstdcat $F | grep '(12,"2023-08-27",1,' | wc -l
75
```

Table schema:
```
CREATE TABLE `itemscenariometrics` (
  `ScenarioId` int NOT NULL,
  `date` date NOT NULL,
  `ItemGroupId` bigint unsigned NOT NULL,
  ...
  PRIMARY KEY (`ScenarioId`,`ItemGroupId`,`date`),
  KEY `itemscenariometrics_date_ScenarioId_ItemGroupId` (`date`,`ScenarioId`,`ItemGroupId`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
/*!50100 PARTITION BY RANGE (to_days(`date`))
SUBPARTITION BY KEY (ScenarioId)
SUBPARTITIONS 75
(PARTITION p_past VALUES LESS THAN (719528) ENGINE = InnoDB,
 PARTITION p2020_h1 VALUES LESS THAN (737963) ENGINE = InnoDB,
 PARTITION p2020_h2 VALUES LESS THAN (738152) ENGINE = InnoDB,
...
 PARTITION p2030_h2 VALUES LESS THAN (741799) ENGINE = InnoDB,
 PARTITION p_future VALUES LESS THAN (3652424) ENGINE = InnoDB) */
 ```