### PR TITLE
Fix macOS build issues with Clang 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,17 @@ endif (PC_GLIB2_VERSION VERSION_GREATER "2.51")
 #endif (PC_GLIB2_VERSION VERSION_LESS "2.68")
 
 option(WITH_SSL "Build SSL support" ON)
+
 if (MARIADB_FOUND AND NOT MARIADB_SSL AND WITH_SSL)
     message(WARNING "MariaDB was not build with SSL so cannot turn SSL on")
     set(WITH_SSL OFF)
+endif()
+
+if (WITH_SSL)
+  FIND_PACKAGE(OpenSSL)
+  if(${OpenSSL_FOUND})
+    include_directories(${OPENSSL_INCLUDE_DIR})
+  endif()
 endif()
 
 set(CMAKE_C_FLAGS "-std=gnu99 -Wall -Wno-deprecated-declarations -Wunused -Wwrite-strings -Wno-strict-aliasing -Wextra -Wshadow -g -Werror ${MYSQL_CFLAGS}")

--- a/src/common.c
+++ b/src/common.c
@@ -1330,41 +1330,55 @@ static gboolean m_queryv(  MYSQL *conn, const gchar *query, void log_fun_1(const
 
 
 gboolean m_query(  MYSQL *conn, const gchar *query, void log_fun(const char *, ...) , const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_queryv(conn, query, log_fun, NULL, fmt,args);
+  gboolean result = m_queryv(conn, query, log_fun, NULL, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 // Executes the query, if there is an error it send critical stopping the process unless the error is ignored
 gboolean m_query_warning(  MYSQL *conn, const gchar *query, const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_queryv(conn, query, m_warning, NULL, fmt,args);
+  gboolean result = m_queryv(conn, query, m_warning, NULL, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 // Executes the query, if there is an error it send critical stopping the process unless the error is ignored
 gboolean m_query_critical(  MYSQL *conn, const gchar *query, const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_queryv(conn, query, m_critical, m_warning, fmt,args);
+  gboolean result = m_queryv(conn, query, m_critical, m_warning, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 
 gboolean m_query_ext(  MYSQL *conn, const gchar *query, void log_fun_1(const char *, ...), void log_fun_2(const char *, ...), const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_queryv(conn, query, log_fun_1, log_fun_2, fmt,args);
+  gboolean result = m_queryv(conn, query, log_fun_1, log_fun_2, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 gboolean m_query_verbose(MYSQL *conn, const char *q, void log_fun(const char *, ...) , const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  gboolean res= m_queryv(conn, q, log_fun, NULL, fmt, args);
+  gboolean res = m_queryv(conn, q, log_fun, NULL, fmt, args);
+  if (fmt)
+    va_end(args);
   if (!res)
     g_message("%s: OK", q);
   return res;
@@ -1381,40 +1395,51 @@ MYSQL_RES *m_resultv(MYSQL_RES * m_result(MYSQL *), MYSQL *conn, const gchar *qu
 }
 
 MYSQL_RES *m_store_result_critical(MYSQL *conn, const gchar *query, const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_resultv(mysql_store_result, conn, query, m_critical, m_warning, fmt, args);
+  MYSQL_RES *result = m_resultv(mysql_store_result, conn, query, m_critical, m_warning, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 MYSQL_RES *m_store_result(MYSQL *conn, const gchar *query, void log_fun(const char *, ...) , const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_resultv(mysql_store_result, conn, query, log_fun, NULL, fmt, args);
+  MYSQL_RES *result = m_resultv(mysql_store_result, conn, query, log_fun, NULL, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 MYSQL_RES *m_use_result(MYSQL *conn, const gchar *query, void log_fun(const char *, ...) , const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
-  return m_resultv(mysql_use_result, conn, query, log_fun, NULL, fmt, args);
+  MYSQL_RES *result = m_resultv(mysql_use_result, conn, query, log_fun, NULL, fmt, args);
+  if (fmt)
+    va_end(args);
+  return result;
 }
 
 struct M_ROW* m_store_result_row(MYSQL *conn, const gchar *query, void log_fun_1(const char *, ...), void log_fun_2(const char *, ...), const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
   struct M_ROW *mr=g_new0(struct M_ROW,1);
   mr->row=NULL;
   mr->res = m_resultv(mysql_store_result, conn, query, log_fun_1, log_fun_2, fmt, args);
+  if (fmt)
+    va_end(args);
   if (mr->res)
     mr->row= mysql_fetch_row(mr->res);
   return mr;
 }
 
 struct M_ROW* m_store_result_single_row(MYSQL *conn, const gchar *query, const char *fmt, ...){
-  va_list args;
+  va_list args = {0};
   if (fmt)
     va_start(args, fmt);
   struct M_ROW *mr=g_new0(struct M_ROW,1);
@@ -1422,10 +1447,11 @@ struct M_ROW* m_store_result_single_row(MYSQL *conn, const gchar *query, const c
   mr->res = m_resultv(mysql_store_result, conn, query, m_critical, m_warning, fmt, args);
   if (mr->res){
     mr->row= mysql_fetch_row(mr->res);
-
-    if (!mr->row)
+    if (!mr->row && fmt)
       m_log(conn, m_critical, m_warning, fmt, args);
   }
+  if (fmt)
+    va_end(args);
   return mr;
 }
 

--- a/src/mydumper/mydumper_start_dump.c
+++ b/src/mydumper/mydumper_start_dump.c
@@ -1337,7 +1337,7 @@ void start_dump(struct configuration *conf) {
   g_async_queue_unref(conf->ready_non_transactional_queue);
   conf->ready_non_transactional_queue=NULL;
 
-  fprintf(mdfile, "[config]\nmax-statement-size = %ld\n", max_statement_size);
+  fprintf(mdfile, "[config]\nmax-statement-size = %" G_GUINT64_FORMAT "\n", max_statement_size);
   fprintf(mdfile, "num-sequences = %d\n", num_sequences);
 
   datetime = g_date_time_new_now_local();

--- a/src/mydumper/mydumper_write.c
+++ b/src/mydumper/mydumper_write.c
@@ -523,7 +523,7 @@ gboolean write_statement(int load_data_file, float *filessize, GString *statemen
 
 void initialize_config_on_string(GString *output){
   g_mutex_lock(max_statement_size_mutex);
-  g_string_append_printf(output,"[config]\nmax-statement-size = %ld\n", max_statement_size);
+  g_string_append_printf(output,"[config]\nmax-statement-size = %" G_GUINT64_FORMAT "\n", max_statement_size);
   g_mutex_unlock(max_statement_size_mutex);
   g_string_append_printf(output, "num-sequences = %d\n", num_sequences);
 }


### PR DESCRIPTION
Hi, I was trying to build mydumper on macOS 15.6 (aarch64) but ran into several issues. I installed the dependencies through Homebrew (MariaDB 12.1.2, OpenSSL 3.5.0) and used apple's system Clang (clang-1700.4.4.1).

The build fails with these compilation errors in about 10 functions: `m_query`, `m_query_warning`, `m_query_critical`, `m_query_ext`, `m_query_verbose`, `m_store_result_critical`, `m_store_result`, `m_use_result`, `m_store_result_row`, `m_store_result_single_row`.

```
/Users/fahadhossain/my-builds/mydumper/src/common.c:1334:7: error: variable 'args' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
 1334 |   if (fmt)
      |       ^~~
/Users/fahadhossain/my-builds/mydumper/src/common.c:1336:51: note: uninitialized use occurs here
 1336 |   return m_queryv(conn, query, log_fun, NULL, fmt,args);
      |                                                   ^~~~
```


And also some SSL linking errors even though I had OpenSSL installed on my system.

```
ld: library 'ssl' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

I tried to work around this at first by disabling SSL with `cmake -DWITH_SSL=OFF` but it was still attempting to link to ssl and crypto, adding `include_directories(${OPENSSL_INCLUDE_DIR})` seems to link ssl and crypto correctly but I wonder if its still correct to link to ssl and crypto if the option is set to OFF.

I also got these format warnings:

```
/Users/fahadhossain/my-builds/mydumper/src/mydumper/mydumper_start_dump.c:1340:59: warning: format specifies type 'long' but the argument has type 'guint64' (aka 'unsigned long long') [-Wformat]
 1340 |   fprintf(mdfile, "[config]\nmax-statement-size = %ld\n", max_statement_size);
      |                                                   ~~~     ^~~~~~~~~~~~~~~~~~
      |                                                   %llu
```

Same thing happens in `src/mydumper/mydumper_write.c`. Using the `G_GUINT64_FORMAT` constant gets rid of this one, so fairly simple "fix".

I managed to get it building with these changes but I'm not familiar enough with the codebase to know if these come with any side effects on any other system. FWIW on macOS 15.6 I now have working builds with both SSL on and off, Would appreciate feedback on whether my approach is correct or I was just missing something in how I was trying to build. 

Changes:
- Initialize va_list variables in variadic functions
- Resolve OpenSSL when WITH_SSL is specified
- Use portable format specifiers for guint64