### PR TITLE
Perf: O(1) lookup for --ignore-errors using GHashTable

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -34,6 +34,7 @@
 extern gboolean help;
 guint errors=0;
 GList *ignore_errors_list=NULL;
+GHashTable *ignore_errors_set=NULL;
 GAsyncQueue *stream_queue = NULL;
 gboolean use_defer= FALSE;
 gboolean check_row_count= FALSE;
@@ -1303,10 +1304,15 @@ void discard_mysql_output(MYSQL *conn){
   }
 }
 
+gboolean should_ignore_error_code(guint error_code) {
+  if (ignore_errors_set == NULL) return FALSE;
+  return g_hash_table_contains(ignore_errors_set, GINT_TO_POINTER(error_code));
+}
+
 static void m_log(MYSQL *conn, void log_fun_1(const char *, ...), void log_fun_2(const char *, ...), const char *fmt, va_list args){
   if (fmt && log_fun_1){
     gchar *c=g_strdup_vprintf(fmt,args);
-    if (log_fun_2 && g_list_find(ignore_errors_list, GINT_TO_POINTER(mysql_errno(conn))))
+    if (log_fun_2 && should_ignore_error_code(mysql_errno(conn)))
       log_fun_2("%s - ERROR %d: %s",c, mysql_errno(conn), mysql_error(conn));
     else{
       if (mysql_errno(conn)){

--- a/src/common.h
+++ b/src/common.h
@@ -56,6 +56,7 @@
 #define BINARY_CHARSET "binary"
 #define AUTO_CHARSET "auto"
 extern GList *ignore_errors_list;
+extern GHashTable *ignore_errors_set;
 extern const gchar *start_replica;
 extern const gchar *stop_replica;
 extern const gchar *start_replica_sql_thread;
@@ -169,6 +170,7 @@ void m_message(const char *fmt, ...);
 void load_hash_of_all_variables_perproduct_from_key_file(GKeyFile *kf, GHashTable * set_session_hash, const gchar *str);
 GRecMutex * g_rec_mutex_new();
 gboolean read_data(FILE *file, GString *data, gboolean *eof, guint *line);
+gboolean should_ignore_error_code(guint error_code);
 gchar *m_date_time_new_now_local();
 
 void print_int(const char*_key, int val);

--- a/src/common_options.c
+++ b/src/common_options.c
@@ -137,8 +137,13 @@ gboolean common_arguments_callback(const gchar *option_name,const gchar *value, 
   } else if (!strcmp(option_name, "--ignore-errors")){
     guint n=0;
     gchar **tmp_ignore_errors_list = g_strsplit(value, ",", 0);
+    if (ignore_errors_set == NULL) {
+      ignore_errors_set = g_hash_table_new(g_direct_hash, g_direct_equal);
+    }
     while(tmp_ignore_errors_list[n]!=NULL){
-      ignore_errors_list=g_list_append(ignore_errors_list,GINT_TO_POINTER(atoi(tmp_ignore_errors_list[n])));
+      gint error_code = atoi(tmp_ignore_errors_list[n]);
+      ignore_errors_list=g_list_append(ignore_errors_list,GINT_TO_POINTER(error_code));
+      g_hash_table_add(ignore_errors_set, GINT_TO_POINTER(error_code));
       n++;
     }
     return TRUE;

--- a/src/myloader/myloader_restore.c
+++ b/src/myloader/myloader_restore.c
@@ -141,7 +141,7 @@ int restore_data_in_gstring_by_statement(struct connection_data *cd, GString *da
       g_warning("Thread %ld using connection %ld - ERROR %d: %s"    , cd->thread_id, cd->connection_id, mysql_errno(cd->thrconn), mysql_error(cd->thrconn));
     }
 
-    if ( mysql_errno(cd->thrconn) != 0 && !g_list_find(ignore_errors_list, GINT_TO_POINTER(mysql_errno(cd->thrconn) ))){
+    if ( mysql_errno(cd->thrconn) != 0 && !should_ignore_error_code(mysql_errno(cd->thrconn))){
       if (mysql_ping(cd->thrconn)) {
         reconnect_connection_data(cd);
         if (!is_schema && commit_count > 1) {


### PR DESCRIPTION
## Summary

Optimizes `--ignore-errors` lookup from O(n) to O(1) using a GHashTable alongside the existing GList.

## Problem

The `--ignore-errors` option stores error codes in a GList. Each error check uses `g_list_find()` which is O(n) - it scans the entire list for every error occurrence. With many ignored errors or high error rates, this becomes a bottleneck.

## Solution

Build a GHashTable (`ignore_errors_set`) alongside the GList when parsing `--ignore-errors`. Use `g_hash_table_contains()` for O(1) lookups instead of `g_list_find()`.

## Changes

| File | Change |
|------|--------|
| `src/common.h` | Add `extern GHashTable *ignore_errors_set` and `should_ignore_error_code()` declaration |
| `src/common.c` | Add `ignore_errors_set` definition and `should_ignore_error_code()` function |
| `src/common_options.c` | Build hash set when parsing `--ignore-errors` option |
| `src/myloader/myloader_restore.c` | Use `should_ignore_error_code()` instead of `g_list_find()` |

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| 50 ignored error codes, 1M errors | 50M comparisons | 1M hash lookups |
| Lookup complexity | O(n) | O(1) |

## Backward Compatibility

- No behavior change
- No new dependencies
- GList is kept for any code that may iterate over the list

## Testing

Tested with existing test cases. The optimization is transparent to users.
