### PR TITLE
Perf: Increase I/O buffer sizes for reduced syscalls

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -441,7 +441,7 @@ guint strcount(gchar *text){
 }
 
 gchar * common_build_schema_table_filename(gchar *_directory, char *database, char *table, const char *suffix){
-  GString *filename = g_string_sized_new(20);
+  GString *filename = g_string_sized_new(128);
   g_string_append_printf(filename, "%s.%s-%s.sql", database, table, suffix);
   gchar *r = g_build_filename(_directory?_directory:filename->str, _directory?filename->str:NULL, NULL);
   g_string_free(filename,TRUE);
@@ -846,7 +846,7 @@ GRecMutex * g_rec_mutex_new(){
 */
 gboolean read_data(FILE *file, GString *data,
                    gboolean *eof, guint *line) {
-  char buffer[4096];
+  char buffer[65536];
   size_t l;
 
   while (fgets(buffer, sizeof(buffer), file)) {

--- a/src/myloader/myloader_restore.c
+++ b/src/myloader/myloader_restore.c
@@ -233,7 +233,7 @@ int restore_insert(struct connection_data *cd, struct thread_data*td,
   guint tr=0,current_offset_line=offset_line-1;
   gchar *current_line=next_line;
   next_line=g_strstr_len(current_line, -1, "\n");
-  GString * new_insert=g_string_sized_new(strlen(insert_statement_prefix));
+  GString * new_insert=g_string_sized_new(strlen(insert_statement_prefix) + 65536);
   guint current_rows=0;
   guint64 transaction_size=0;
   do {
@@ -440,7 +440,7 @@ int restore_data_from_mysqldump_file(struct thread_data *td, const char *filenam
 
   FILE *infile=NULL;
   gboolean eof = FALSE;
-  GString *data = g_string_sized_new(256);
+  GString *data = g_string_sized_new(is_schema ? 4096 : 65536);
   guint line=0,preline=0;
   gchar *path = g_build_filename(directory, filename, NULL);
   infile=myl_open(path,"r");
@@ -517,7 +517,7 @@ int restore_data_from_mydumper_file(struct thread_data *td, const char *filename
 
   FILE *infile=NULL;
   gboolean eof = FALSE;
-  GString *data = g_string_sized_new(256);
+  GString *data = g_string_sized_new(is_schema ? 4096 : 65536);
   guint line=0,preline=0;
   gchar *path = g_build_filename(directory, filename, NULL);
   infile=myl_open(path,"r");


### PR DESCRIPTION
## Summary

Increases I/O buffer sizes to reduce syscall overhead and memory reallocations during data processing.

## Problem

Small default buffer sizes cause:
1. More `fgets()` calls for large INSERT statements
2. Frequent `g_string_maybe_expand()` calls as GString buffers grow
3. Increased syscall overhead when reading data files

## Changes

| File | Location | Before | After | Rationale |
|------|----------|--------|-------|-----------|
| `src/common.c` | `read_data()` | 4KB | 64KB | Fewer fgets calls for large data |
| `src/common.c` | `common_build_schema_table_filename()` | 20 bytes | 128 bytes | Typical filenames are longer |
| `src/myloader/myloader_restore.c` | `restore_data_in_gstring_by_statement()` | prefix length | prefix + 64KB | INSERT statements often exceed prefix |
| `src/myloader/myloader_restore.c` | `restore_data_from_mysqldump_file()` | 256 bytes | 4KB (schema) / 64KB (data) | Data files are much larger |
| `src/myloader/myloader_restore.c` | `restore_data_from_mydumper_file()` | 256 bytes | 4KB (schema) / 64KB (data) | Data files are much larger |

## Performance Impact

| Metric | Improvement |
|--------|-------------|
| fgets calls per MB | ~16x fewer (64KB vs 4KB buffer) |
| GString reallocations | Significantly reduced |
| Syscall overhead | Lower |

## Backward Compatibility

- No behavior change
- No new CLI options
- Schema files still use smaller buffers (4KB) since they're typically smaller

## Testing

Tested with existing test cases. Purely internal buffer sizing change.
