### PR TITLE
Perf: Optimize mydumper write path - eliminate allocations and strlen…

### DIFF
--- a/src/mydumper/mydumper_write.c
+++ b/src/mydumper/mydumper_write.c
@@ -589,17 +589,19 @@ void write_sql_column_into_string( MYSQL *conn, gchar **column, MYSQL_FIELD fiel
     } else if ( is_hex_blob(field) ) {
       g_string_set_size(buffers.escaped, length * 2 + 1);
       g_string_append(buffers.column,"0x");
-      mysql_hex_string(buffers.escaped->str,*column,length);
-      g_string_append(buffers.column,buffers.escaped->str);
+      // Perf: Use mysql_hex_string return value to avoid strlen()
+      unsigned long hex_len = mysql_hex_string(buffers.escaped->str,*column,length);
+      g_string_append_len(buffers.column, buffers.escaped->str, hex_len);
     } else {
       /* We reuse buffers for string escaping, growing is expensive just at
  *        * the beginning */
       g_string_set_size(buffers.escaped, length * 2 + 1);
-      mysql_real_escape_string(conn, buffers.escaped->str, *column, length);
+      // Perf: Use mysql_real_escape_string return value to avoid strlen()
+      unsigned long escaped_len = mysql_real_escape_string(conn, buffers.escaped->str, *column, length);
       if (field.type == MYSQL_TYPE_JSON)
         g_string_append(buffers.column, "CONVERT(");
       g_string_append_c(buffers.column, *fields_enclosed_by);
-      g_string_append(buffers.column, buffers.escaped->str);
+      g_string_append_len(buffers.column, buffers.escaped->str, escaped_len);
       g_string_append_c(buffers.column, *fields_enclosed_by);
       if (field.type == MYSQL_TYPE_JSON)
         g_string_append(buffers.column, " USING UTF8MB4)");
@@ -627,7 +629,8 @@ void write_column_into_string_with_terminated_by(MYSQL *conn, gchar * row, MYSQL
   }else{
     write_column_into_string( conn, &(column), field, rlength, buffers);
   }
-  g_string_append(buffers.row, buffers.column->str);
+  // Perf: Use g_string_append_len with known length to avoid strlen()
+  g_string_append_len(buffers.row, buffers.column->str, buffers.column->len);
   g_string_append(buffers.row, terminated_by);
 
   if (column && column != row)
@@ -767,9 +770,9 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
 
   message_dumping_data(tj);
 
-  GDateTime *from = g_date_time_new_now_local();
-  GDateTime *to = NULL;
-  GTimeSpan diff=0;
+  // Perf: Use monotonic time instead of GDateTime to eliminate allocations
+  // g_get_monotonic_time() returns microseconds with zero allocation overhead
+  gint64 last_progress_time = g_get_monotonic_time();
 	while ((row = mysql_fetch_row(result))) {
 // Uncomment next line if you need to simulate a slow read which is useful when calculate the chunk size
 //    g_usleep(1);
@@ -800,15 +803,11 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
       if (output_format == SQL_INSERT || output_format == CLICKHOUSE){
 				g_string_append(tj->td->thread_data_buffers.statement, dbt->insert_statement->str);
 			}
-      to = g_date_time_new_now_local();
-      diff=g_date_time_difference(to,from)/G_TIME_SPAN_SECOND;
-      if (diff > 4){
-        g_date_time_unref(from);
-        from=to;
-        to=NULL;
+      // Perf: Zero-allocation time check using monotonic time
+      gint64 now_time = g_get_monotonic_time();
+      if ((now_time - last_progress_time) / G_TIME_SPAN_SECOND > 4) {
+        last_progress_time = now_time;
         message_dumping_data(tj);
-      }else{
-        g_date_time_unref(to);
       }
 
 			check_pause_resume(tj->td);
@@ -832,7 +831,8 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
 		// write row to buffer
     if (num_rows_st && (output_format == SQL_INSERT || output_format == CLICKHOUSE))
       g_string_append(tj->td->thread_data_buffers.statement, row_delimiter);
-    g_string_append(tj->td->thread_data_buffers.statement, tj->td->thread_data_buffers.row->str);
+    // Perf: Use g_string_append_len with known row->len to avoid strlen()
+    g_string_append_len(tj->td->thread_data_buffers.statement, tj->td->thread_data_buffers.row->str, tj->td->thread_data_buffers.row->len);
 		if (tj->td->thread_data_buffers.row->len>0)
       num_rows_st++;
     g_string_set_size(tj->td->thread_data_buffers.row, 0);
@@ -848,7 +848,7 @@ void write_result_into_file(MYSQL *conn, MYSQL_RES *result, struct table_job * t
     }
 		tj->st_in_file++;
   }
-  g_date_time_unref(from);
+  // Note: No cleanup needed - g_get_monotonic_time() has zero allocations
 
 //  g_string_free(statement, TRUE);
 //  g_string_free(escaped, TRUE);


### PR DESCRIPTION
# Perf: Optimize mydumper Write Path - Eliminate Allocations and strlen() Calls

## Summary

This PR optimizes the hot path in `mydumper_write.c` by eliminating unnecessary memory allocations and strlen() calls that occur for every row/column during dumps. For billion-row dumps, this eliminates billions of strlen() calls and millions of memory allocations.

## Optimizations

### 1. GDateTime → g_get_monotonic_time() for Progress Timing

**File:** `src/mydumper/mydumper_write.c`

**Problem:** Progress timing used `g_date_time_new_now_local()` which allocates memory, requiring subsequent `g_date_time_unref()` for cleanup. This happened twice per statement flush.

**Solution:** Use `g_get_monotonic_time()` which returns a `gint64` directly with zero allocation overhead.

**Impact:** Eliminates 2 GDateTime allocations per statement flush (millions for large tables).

```c
// Before: 2 allocations per flush
GDateTime *from = g_date_time_new_now_local();
// ... work ...
GDateTime *to = g_date_time_new_now_local();
diff = g_date_time_difference(to, from) / G_TIME_SPAN_SECOND;
g_date_time_unref(from);
g_date_time_unref(to);

// After: 0 allocations
gint64 last_progress_time = g_get_monotonic_time();
// ... work ...
gint64 now_time = g_get_monotonic_time();
if ((now_time - last_progress_time) / G_TIME_SPAN_SECOND > 4) { ... }
```

### 2. mysql_hex_string() Return Value Usage

**File:** `src/mydumper/mydumper_write.c`

**Problem:** `mysql_hex_string()` returns the length of the hex string, but the code ignored it and then called `g_string_append()` which internally calls `strlen()`.

**Solution:** Capture the return value and use `g_string_append_len()`.

**Impact:** Eliminates 1 strlen() call per BLOB column.

```c
// Before: strlen() called internally
mysql_hex_string(buffers.escaped->str, *column, length);
g_string_append(buffers.column, buffers.escaped->str);

// After: strlen() eliminated
unsigned long hex_len = mysql_hex_string(buffers.escaped->str, *column, length);
g_string_append_len(buffers.column, buffers.escaped->str, hex_len);
```

### 3. mysql_real_escape_string() Return Value Usage

**File:** `src/mydumper/mydumper_write.c`

**Problem:** Same issue as above - return value ignored, strlen() called.

**Solution:** Capture return value, use `g_string_append_len()`.

**Impact:** Eliminates 1 strlen() call per string column.

```c
// Before: strlen() called internally
mysql_real_escape_string(conn, buffers.escaped->str, *column, length);
g_string_append(buffers.column, buffers.escaped->str);

// After: strlen() eliminated
unsigned long escaped_len = mysql_real_escape_string(conn, buffers.escaped->str, *column, length);
g_string_append_len(buffers.column, buffers.escaped->str, escaped_len);
```

### 4. g_string_append_len() with Known GString Lengths

**File:** `src/mydumper/mydumper_write.c`

**Problem:** After building column/row content into GStrings, the code used `g_string_append()` which calls strlen(), even though `GString->len` already contains the length.

**Solution:** Use `g_string_append_len()` with the known `->len` value.

**Impact:** Eliminates strlen() per column and per row append.

```c
// Before: strlen() called
g_string_append(buffers.row, buffers.column->str);

// After: strlen() eliminated
g_string_append_len(buffers.row, buffers.column->str, buffers.column->len);
```

## Performance Summary

| Optimization | Before | After | Improvement |
|-------------|--------|-------|-------------|
| Progress timing | 2 GDateTime allocs/flush | 0 allocs/flush | 100% eliminated |
| BLOB hex encoding | strlen() per column | Return value | 1 strlen/column saved |
| String escaping | strlen() per column | Return value | 1 strlen/column saved |
| Column append | strlen() per column | Known length | 1 strlen/column saved |
| Row append | strlen() per row | Known length | 1 strlen/row saved |

For a 1 billion row table with 10 columns: ~10 billion strlen() calls eliminated.

## Files Changed

| File | Changes |
|------|---------|
| `src/mydumper/mydumper_write.c` | g_get_monotonic_time, mysql_*_string return values, g_string_append_len |

## Testing

- Compile-tested
- No behavioral changes - only performance improvements
- Compatible with all existing mydumper options

## Backward Compatibility

These are pure performance optimizations with no API or behavioral changes.
