### PR TITLE
Perf: cache strlen result in escape_string to eliminate duplicate call

### DIFF
--- a/src/mydumper/mydumper_common.c
+++ b/src/mydumper/mydumper_common.c
@@ -87,8 +87,10 @@ gchar *get_ref_table(gchar *k){
 }
 
 char * escape_string(MYSQL *conn, char *str){
-  char * r=g_new(char, strlen(str) * 2 + 1);
-  mysql_real_escape_string(conn, r, str, strlen(str));
+  // Perf: Cache strlen result instead of calling twice
+  gulong len = strlen(str);
+  char * r=g_new(char, len * 2 + 1);
+  mysql_real_escape_string(conn, r, str, len);
   return r;
 }
 


### PR DESCRIPTION
# Perf: Cache strlen Result in escape_string()

## Summary

This PR eliminates a duplicate `strlen()` call in the `escape_string()` function, which is called for every non-numeric column during dump operations.

## Problem

The original `escape_string()` function called `strlen(str)` twice:

```c
char * escape_string(MYSQL *conn, char *str){
  char * r = g_new(char, strlen(str) * 2 + 1);        // First strlen
  mysql_real_escape_string(conn, r, str, strlen(str)); // Second strlen
  return r;
}
```

This function is called in the hot path during mydumper - once per string column per row.

## Solution

Cache the `strlen()` result:

```c
char * escape_string(MYSQL *conn, char *str){
  gulong len = strlen(str);                           // Single strlen
  char * r = g_new(char, len * 2 + 1);
  mysql_real_escape_string(conn, r, str, len);
  return r;
}
```

## Performance Impact

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| 1M rows, 10 string columns | 20M strlen calls | 10M strlen calls | 50% reduction |
| Average string length 50 bytes | 1B byte comparisons | 500M byte comparisons | 50% faster |

## Files Changed

| File | Changes |
|------|---------|
| `src/mydumper/mydumper_common.c` | Cache strlen result |

## Testing

- Compile-tested
- No behavioral changes - only performance improvements

## Backward Compatibility

This is a pure performance optimization with no API or behavioral changes.
