### PR TITLE
Fix: Remove erroneous argument to get_product_name()

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -275,11 +275,11 @@ gboolean m_key_file_has_group (GKeyFile* kf, const gchar* group_name){
   return FALSE;
 }
 
-void load_options_for_product_from_key_file(GKeyFile *kf, GOptionContext *context, const gchar *app, int product, int major, int secondary, int revision){
+void load_options_for_product_from_key_file(GKeyFile *kf, GOptionContext *context, const gchar *app, int major, int secondary, int revision){
   GString *group=g_string_sized_new(50);
   g_string_append(group, app);
   g_string_append(group, "_");
-  g_string_append(group, g_ascii_strdown(get_product_name(product),-1));
+  g_string_append(group, g_ascii_strdown(get_product_name(),-1));
   g_message("searching group group %s",group->str);
   if (g_key_file_has_group(kf,group->str)){
     g_message("group found %s",group->str);

--- a/src/common.h
+++ b/src/common.h
@@ -230,4 +230,4 @@ void *monitor_throttling_thread (void *queue);
 gchar *set_names_statement_template(gchar *_set_names);
 void execute_set_names(MYSQL *conn, gchar *_set_names);
 gchar * common_build_schema_table_filename(gchar *_directory, char *database, char *table, const char *suffix);
-void load_options_for_product_from_key_file(GKeyFile *kf, GOptionContext *context, const gchar *app, int product, int major, int secondary, int revision);
+void load_options_for_product_from_key_file(GKeyFile *kf, GOptionContext *context, const gchar *app, int major, int secondary, int revision);

--- a/src/mydumper/mydumper_start_dump.c
+++ b/src/mydumper/mydumper_start_dump.c
@@ -401,7 +401,7 @@ MYSQL *create_main_connection(GOptionContext *context) {
   set_global = g_string_new(NULL);
   set_global_back = g_string_new(NULL);
   server_detect(conn);
-  load_options_for_product_from_key_file(key_file, context, "mydumper", get_product(), get_major(), get_secondary(), get_revision());
+  load_options_for_product_from_key_file(key_file, context, "mydumper", get_major(), get_secondary(), get_revision());
   GHashTable * set_session_hash = mydumper_initialize_hash_of_session_variables();
   GHashTable * set_global_hash = g_hash_table_new ( g_str_hash, g_str_equal );
   if (key_file != NULL ){

--- a/src/server_detect.c
+++ b/src/server_detect.c
@@ -52,7 +52,7 @@ int get_revision(){
       return revision;
 }
 
-const gchar * get_product_name(){
+const gchar * get_product_name(void){
   switch (get_product()){
     case SERVER_TYPE_PERCONA:   return "Percona"; break;
     case SERVER_TYPE_MYSQL:     return "MySQL";   break;

--- a/src/server_detect.h
+++ b/src/server_detect.h
@@ -36,7 +36,7 @@ int get_major();
 int get_secondary();
 int get_revision();
 gboolean is_mysql_like();
-const gchar * get_product_name();
+const gchar * get_product_name(void);
 #endif
 
 


### PR DESCRIPTION
This patch fixes a compiler compatibility issue where an unused argument was being passed to get_product_name() which doesn't accept parameters.

## Changes
- Removed product argument from get_product_name() call in src/common.c:282
- Removed unused product parameter from load_options_for_product_from_key_file() function
- Updated function declarations to use (void) for strict parameter checking
- Updated function call in mydumper_start_dump.c

## Testing
### Automated Tests (Debian)
- Builds successfully on Debian Bookworm
- All tests pass against MariaDB 10.6.16
- All tests pass against MySQL 8.4.5

### Manual Testing (macOS)
- Builds successfully on macOS with Clang
- Manual testing verified against MariaDB 10.6.16
- Manual testing verified against MySQL 8.4.5 
- Product detection working correctly for both database types

This resolves compilation issues on stricter compilers while maintaining full backward compatibility.