### PR TITLE
Perf: Use g_list_prepend for integer chunk list operations

### DIFF
--- a/src/mydumper/mydumper_integer_chunks.c
+++ b/src/mydumper/mydumper_integer_chunks.c
@@ -351,7 +351,9 @@ struct chunk_step_item *get_next_integer_chunk(struct db_table *dbt){
         new_csi->part+=pow(2,csi->deep);
         update_where_on_integer_step(new_csi);
 
-        dbt->chunks=g_list_append(dbt->chunks,new_csi);
+        // Perf: Use g_list_prepend (O(1)) instead of g_list_append (O(n))
+        // Order doesn't matter since chunks are processed via async queue
+        dbt->chunks=g_list_prepend(dbt->chunks,new_csi);
         // should I push them again? isn't it pointless?
 //        g_async_queue_push(dbt->chunks_queue, csi);
 //        g_async_queue_push(dbt->chunks_queue, new_csi);
@@ -395,7 +397,8 @@ struct chunk_step_item *get_next_integer_chunk(struct db_table *dbt){
               new_csi->next=new_csi_next;
 
               new_csi->next->prefix = new_csi->where;
-              dbt->chunks=g_list_append(dbt->chunks,new_csi);
+              // Perf: Use g_list_prepend (O(1)) instead of g_list_append (O(n))
+              dbt->chunks=g_list_prepend(dbt->chunks,new_csi);
               g_async_queue_push(dbt->chunks_queue, csi);
               g_async_queue_push(dbt->chunks_queue, new_csi);
               g_mutex_unlock(csi->next->mutex);
@@ -419,7 +422,8 @@ struct chunk_step_item *get_next_integer_chunk(struct db_table *dbt){
           trace("Multicolumn table splited min: %lld max: %lld ", new_csi->chunk_step->integer_step.type.unsign.min, new_csi->chunk_step->integer_step.type.unsign.max);
         else
           trace("Multicolumn table splited min: %lld max: %lld ", new_csi->chunk_step->integer_step.type.sign.min, new_csi->chunk_step->integer_step.type.sign.max);
-        dbt->chunks=g_list_append(dbt->chunks,new_csi);
+        // Perf: Use g_list_prepend (O(1)) instead of g_list_append (O(n))
+        dbt->chunks=g_list_prepend(dbt->chunks,new_csi);
         g_async_queue_push(dbt->chunks_queue, csi);
         g_async_queue_push(dbt->chunks_queue, new_csi);
         g_mutex_unlock(csi->mutex);


### PR DESCRIPTION
## Summary

Replace `g_list_append()` with `g_list_prepend()` in integer chunk splitting hot path.

## Problem

`g_list_append()` is O(n) as it traverses to find the tail, while `g_list_prepend()` is O(1).

For tables with many chunks (100+), the current code exhibits O(n²) behavior during chunk splitting.

## Solution

```c
// BEFORE: O(n) per insertion
dbt->chunks = g_list_append(dbt->chunks, new_csi);

// AFTER: O(1) per insertion  
dbt->chunks = g_list_prepend(dbt->chunks, new_csi);
```

Order doesn't matter since chunks are processed via `GAsyncQueue` (FIFO ordering handled there).

## Locations Changed

| Line | Context |
|------|---------|
| 354 | Last step chunk split |
| 398 | Multicolumn chunk split |
| 422 | Regular chunk split |

## Complexity Analysis

```
With N chunks created:
  BEFORE: O(1 + 2 + 3 + ... + N) = O(N²)
  AFTER:  O(1 + 1 + 1 + ... + 1) = O(N)
```

## Testing

- Builds cleanly on macOS and Linux
- No behavioral changes (same chunks created, just different list order which is irrelevant for async queue processing)