### PR TITLE
Adding --load-data-tmp-directory to distinguish LOAD DATA tmp fifo files and other fifo files

### DIFF
--- a/src/myloader/myloader.c
+++ b/src/myloader/myloader.c
@@ -168,6 +168,16 @@ void initialize_directories(){
     // Set fifo temporary director
     fifo_directory=build_tmp_dir_name();
   }
+
+  if (load_data_tmp_directory){
+    if (fifo_directory[0] != '/' ){
+      gchar *tmp_load_data_tmp_directory=load_data_tmp_directory;
+      load_data_tmp_directory=g_strdup_printf("%s/%s", current_dir, tmp_load_data_tmp_directory);
+    }
+  }else{
+    load_data_tmp_directory=build_tmp_dir_name();
+  }
+
   g_free(current_dir);
 }
 
@@ -265,6 +275,7 @@ void print_help(){
     print_string("defaults-file",defaults_file);
     print_string("defaults-extra-file",defaults_extra_file);
     print_string("fifodir",fifo_directory);
+    print_string("load-data-tmp-directory",load_data_tmp_directory);
     exit(EXIT_SUCCESS);
 }
 
@@ -419,8 +430,9 @@ int main(int argc, char *argv[]) {
   if(stream && !no_stream)
     create_dir(directory);
   create_dir(fifo_directory);
+  create_dir(load_data_tmp_directory);
 
-  g_message("Using %s as FIFO directory, please remove it if restoration fails", fifo_directory);
+  g_message("Using %s as FIFO directory and %s as LOAD DATA temporary directory, please remove them if restoration fails", fifo_directory, load_data_tmp_directory);
 
   start_pmm_thread((void *)&conf);
 
@@ -682,6 +694,7 @@ int main(int argc, char *argv[]) {
 
   if (key_file)  g_key_file_free(key_file);
   g_remove(fifo_directory);
+  g_remove(load_data_tmp_directory);
   g_message("Restore completed");
 
   if (logoutfile) {

--- a/src/myloader/myloader_arguments.c
+++ b/src/myloader/myloader_arguments.c
@@ -29,6 +29,7 @@ gchar *optimize_keys_str=NULL;
 gchar *checksum_str=NULL;
 gboolean set_gtid_purge = FALSE;
 gchar *fifo_directory = NULL;
+gchar *load_data_tmp_directory=NULL;
 gboolean show_warnings=FALSE;
 GList *ignore_set_list=NULL;
 gboolean mysqldump = FALSE;
@@ -143,7 +144,9 @@ static GOptionEntry entries[] = {
     {"logfile", 'L', 0, G_OPTION_ARG_FILENAME, &logfile,
      "Log file name to use, by default stdout is used", NULL},
     {"fifodir", 0, 0, G_OPTION_ARG_FILENAME, &fifo_directory,
-     "Directory where the FIFO files will be created when needed. Default: Same as backup", NULL},
+     "Directory where the FIFO files will be created when needed. Default: temporary directoy will be created", NULL},
+    {"load-data-tmp-dir", 0, 0, G_OPTION_ARG_FILENAME, &load_data_tmp_directory,
+     "Directory where the FIFO temporary files will be created when needed for LOAD DATA statements. Default: temporary directoy will be created", NULL},
     {"database", 'B', 0, G_OPTION_ARG_STRING, &target_db,
      "An alternative database to restore into", NULL},
     {"show-warnings", 0,0, G_OPTION_ARG_NONE, &show_warnings, 

--- a/src/myloader/myloader_global.h
+++ b/src/myloader/myloader_global.h
@@ -38,6 +38,7 @@ extern char *defaults_extra_file;
 extern GKeyFile * key_file;
 extern gchar *input_directory;
 extern gchar *fifo_directory;
+extern gchar *load_data_tmp_directory;
 extern gchar *tables_list;
 extern gboolean help;
 extern char **tables;

--- a/src/myloader/myloader_restore.c
+++ b/src/myloader/myloader_restore.c
@@ -695,9 +695,9 @@ int restore_data_from_mydumper_file(struct thread_data *td, const char *filename
 //          int load_data_child_pid = 0;  // Issue #2075: Track subprocess for FIFO unlink
           gboolean is_fifo = get_command_and_basename(load_data_filename, &command, &load_data_fifo_filename);
           if (is_fifo){
-            if (fifo_directory != NULL){
+            if (load_data_tmp_directory != NULL){
               new_data = g_string_new_len(data->str, from - data->str);
-              g_string_append(new_data, fifo_directory);
+              g_string_append(new_data, load_data_tmp_directory);
               g_string_append_c(new_data, '/');
               g_string_append(new_data, from);
               // Perf: Use strchr instead of g_strstr_len for single-char search
@@ -716,8 +716,8 @@ int restore_data_from_mydumper_file(struct thread_data *td, const char *filename
             }
             *to='\'';
 
-            if (fifo_directory != NULL){
-              new_load_data_fifo_filename=g_strdup_printf("%s/%s", fifo_directory, load_data_fifo_filename);
+            if (load_data_tmp_directory != NULL){
+              new_load_data_fifo_filename=g_strdup_printf("%s/%s", load_data_tmp_directory, load_data_fifo_filename);
               g_free(load_data_fifo_filename);
               load_data_fifo_filename=new_load_data_fifo_filename;
             }


### PR DESCRIPTION
The option --load-data-tmp-directory has been added to distinguish LOAD DATA temporary fifo files of the other fifo files. 
Take into account that LOAD DATA temporary fifo files can be removed, so, in the future we could determine a default dir and fail if the dir exists and we could also add an option to clear the content of that directory.