### PR TITLE
Adding object_to_import in config file

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -250,6 +250,10 @@ void load_per_table_info_from_key_file(GKeyFile *kf, struct configuration_per_ta
             value = g_key_file_get_value(kf,groups[i],keys[j],&error);
             g_hash_table_insert(cpt->all_object_to_export, g_strdup(groups[i]), g_strdup(value));
           }
+          if (g_strcmp0(keys[j],"object_to_import") == 0){
+            value = g_key_file_get_value(kf,groups[i],keys[j],&error);
+            g_hash_table_insert(cpt->all_object_to_import, g_strdup(groups[i]), g_strdup(value));
+          }
           if (g_strcmp0(keys[j],"partition_regex") == 0){
             value = g_key_file_get_value(kf,groups[i],keys[j],&error);
             pcre2_code *r=NULL; 
@@ -1306,6 +1310,7 @@ void initialize_conf_per_table(struct configuration_per_table *cpt){
   cpt->all_columns_on_insert_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
 
   cpt->all_object_to_export=g_hash_table_new ( g_str_hash, g_str_equal );
+  cpt->all_object_to_import=g_hash_table_new ( g_str_hash, g_str_equal );
 
   cpt->all_partition_regex_per_table=g_hash_table_new ( g_str_hash, g_str_equal );
 
@@ -1322,34 +1327,34 @@ gboolean str_list_has_str(gchar ** str_list, const gchar* str){
   return FALSE;
 }
 
-void parse_object_to_export(struct object_to_export *object_to_export,gchar *val){
-  object_to_export->no_data=FALSE;
-  object_to_export->no_schema=FALSE;
-  object_to_export->no_view=FALSE;
-  object_to_export->no_trigger=FALSE;
-  object_to_export->no_index=FALSE;
-  object_to_export->no_constraint=FALSE;
+void parse_object_scope(struct object_scope *object_scope,gchar *val){
+  object_scope->no_data=FALSE;
+  object_scope->no_schema=FALSE;
+  object_scope->no_view=FALSE;
+  object_scope->no_trigger=FALSE;
+  object_scope->no_index=FALSE;
+  object_scope->no_constraint=FALSE;
   if (!val)
     return;
   gchar **split_option = g_strsplit(val, ",", 4);
-  object_to_export->no_data=!str_list_has_str(split_option,"DATA");
-  object_to_export->no_schema=!str_list_has_str(split_option,"SCHEMA");
-  object_to_export->no_trigger=!str_list_has_str(split_option,"TRIGGER");
+  object_scope->no_data=!str_list_has_str(split_option,"DATA");
+  object_scope->no_schema=!str_list_has_str(split_option,"SCHEMA");
+  object_scope->no_trigger=!str_list_has_str(split_option,"TRIGGER");
   if (str_list_has_str(split_option,"ALL")){
-    object_to_export->no_data=FALSE;
-    object_to_export->no_schema=FALSE;
-    object_to_export->no_view=FALSE;
-    object_to_export->no_index=FALSE;
-    object_to_export->no_constraint=FALSE;
-    object_to_export->no_trigger=FALSE;
+    object_scope->no_data=FALSE;
+    object_scope->no_schema=FALSE;
+    object_scope->no_view=FALSE;
+    object_scope->no_index=FALSE;
+    object_scope->no_constraint=FALSE;
+    object_scope->no_trigger=FALSE;
   }
   if (str_list_has_str(split_option,"NONE")){
-    object_to_export->no_data=TRUE;
-    object_to_export->no_schema=TRUE;
-    object_to_export->no_view=TRUE;
-    object_to_export->no_index=TRUE;
-    object_to_export->no_constraint=TRUE;
-    object_to_export->no_trigger=TRUE;
+    object_scope->no_data=TRUE;
+    object_scope->no_schema=TRUE;
+    object_scope->no_view=TRUE;
+    object_scope->no_index=TRUE;
+    object_scope->no_constraint=TRUE;
+    object_scope->no_trigger=TRUE;
   }
   g_strfreev(split_option);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -73,7 +73,7 @@ extern guint throttle_max_usleep_limit;
 void initialize_zstd_cmd();
 void initialize_gzip_cmd();
 
-struct object_to_export{
+struct object_scope{
   gboolean no_data;
   gboolean no_schema;
   gboolean no_view;
@@ -91,6 +91,7 @@ struct configuration_per_table{
   GHashTable *all_columns_on_select_replace_per_table;
   GHashTable *all_columns_on_insert_per_table;
   GHashTable *all_object_to_export;
+  GHashTable *all_object_to_import;
   GHashTable *all_partition_regex_per_table;
   GHashTable *all_rows_per_table;
 };
@@ -213,7 +214,7 @@ extern guint g_get_num_processors (void);
 char *show_warnings_if_possible(MYSQL *conn);
 int global_process_create_table_statement (gchar * statement, GString *create_table_statement, GString *alter_table_statement, GString *alter_table_constraint_statement, gchar *real_table, gboolean split_indexes);
 void initialize_conf_per_table(struct configuration_per_table *cpt);
-void parse_object_to_export(struct object_to_export *object_to_export,gchar *val);
+void parse_object_scope(struct object_scope *object_to_export,gchar *val);
 gchar *build_dbt_key(gchar *a, gchar *b);
 gchar *build_config_file_dbt_key(const gchar *a, const gchar *b);
 void discard_mysql_output(MYSQL *conn);

--- a/src/mydumper/mydumper_start_dump.c
+++ b/src/mydumper/mydumper_start_dump.c
@@ -62,7 +62,7 @@ GList *schema_post = NULL;
 gboolean it_is_a_consistent_backup = FALSE;
 GHashTable *all_dbts=NULL;
 char * (*identifier_quote_character_protect)(char *r);
-struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 gboolean replica_stopped = FALSE;
 gboolean merge_dumpdir= FALSE;
 gboolean clear_dumpdir= FALSE;

--- a/src/mydumper/mydumper_table.c
+++ b/src/mydumper/mydumper_table.c
@@ -414,7 +414,7 @@ gboolean new_db_table(struct db_table **d, MYSQL *conn, struct configuration *co
     dbt->escaped_table = escape_string(conn,dbt->table);
     dbt->where=m_coalesce_hash(conf_per_table.all_where_per_table, config_file_dbt_key, any_db_config_file_dbt_key, any_table_config_file_dbt_key);
     dbt->limit=m_coalesce_hash(conf_per_table.all_limit_per_table, config_file_dbt_key, any_db_config_file_dbt_key, any_table_config_file_dbt_key);
-    parse_object_to_export(&(dbt->object_to_export), m_coalesce_hash(conf_per_table.all_object_to_export, config_file_dbt_key, any_db_config_file_dbt_key, any_table_config_file_dbt_key));
+    parse_object_scope(&(dbt->object_to_export), m_coalesce_hash(conf_per_table.all_object_to_export, config_file_dbt_key, any_db_config_file_dbt_key, any_table_config_file_dbt_key));
 
     dbt->partition_regex=m_coalesce_hash(conf_per_table.all_partition_regex_per_table, config_file_dbt_key, any_db_config_file_dbt_key, any_table_config_file_dbt_key);
     dbt->max_threads_per_table=max_threads_per_table;

--- a/src/mydumper/mydumper_table.h
+++ b/src/mydumper/mydumper_table.h
@@ -34,7 +34,7 @@ struct db_table {
   char *escaped_table;
   char *min;
   char *max;
-  struct object_to_export object_to_export;
+  struct object_scope object_to_export;
   GString *select_fields;
   gboolean complete_insert;
   GString *insert_statement;

--- a/src/myloader/myloader.c
+++ b/src/myloader/myloader.c
@@ -91,7 +91,7 @@ extern guint optimize_keys_batchsize;
 
 const char DIRECTORY[] = "import";
 
-struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+struct configuration_per_table conf_per_table = {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 GHashTable * set_session_hash=NULL;
 
 GHashTable * myloader_initialize_hash_of_session_variables(){

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -687,10 +687,10 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
 //          if (real_table_name) g_free(real_table_name);
   //        if (table_filename) g_free(table_filename);
           real_table_name=NULL;
-          dbt->data_checksum=    dbt->object_to_export.no_data   ?NULL:get_value(kf,groups[j],"data_checksum");
-          dbt->schema_checksum=  dbt->object_to_export.no_schema ?NULL:get_value(kf,groups[j],"schema_checksum");
-          dbt->indexes_checksum= dbt->object_to_export.no_schema ?NULL:get_value(kf,groups[j],"indexes_checksum");
-          dbt->triggers_checksum=dbt->object_to_export.no_trigger?NULL:get_value(kf,groups[j],"triggers_checksum");
+          dbt->data_checksum=    dbt->object_to_import.no_data   ?NULL:get_value(kf,groups[j],"data_checksum");
+          dbt->schema_checksum=  dbt->object_to_import.no_schema ?NULL:get_value(kf,groups[j],"schema_checksum");
+          dbt->indexes_checksum= dbt->object_to_import.no_schema ?NULL:get_value(kf,groups[j],"indexes_checksum");
+          dbt->triggers_checksum=dbt->object_to_import.no_trigger?NULL:get_value(kf,groups[j],"triggers_checksum");
           value=get_value(kf,groups[j],"is_view");
           if (value != NULL && g_strcmp0(value,"1")==0){
             dbt->is_view=TRUE;
@@ -776,7 +776,7 @@ gboolean process_schema_post_filename(gchar *filename, enum restore_job_statemen
     }
 		append_new_db_table(&dbt, _database, NULL, table_name);//, 0, NULL);
   }
-  if ( object == TRIGGER || dbt==NULL || !dbt->object_to_export.no_trigger){
+  if ( object == TRIGGER || dbt==NULL || !dbt->object_to_import.no_trigger){
     struct restore_job *rj = new_schema_restore_job(filename, JOB_RESTORE_SCHEMA_FILENAME, NULL, _database, NULL, object); //TRIGGER or POST
     g_async_queue_push(_conf->post_queue, new_control_job(JOB_RESTORE,rj,_database));
 	}
@@ -828,7 +828,7 @@ gboolean process_data_filename(char * filename){
       }
     }
   }
-	if (!dbt->object_to_export.no_data){
+	if (!dbt->object_to_import.no_data){
     struct restore_job *rj = new_data_restore_job( g_strdup(filename), JOB_RESTORE_FILENAME, dbt, part, sub_part);
     table_lock(dbt);
     g_atomic_int_add(&(dbt->remaining_jobs), 1);

--- a/src/myloader/myloader_restore_job.c
+++ b/src/myloader/myloader_restore_job.c
@@ -264,8 +264,8 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
 // CONSTRAINTS
       if (!source_db || g_strcmp0(dbt->database->source_database,source_db)==0){
         if ( !no_schemas && (
-             (rj->data.srj->object==INDEXES && !dbt->object_to_export.no_index ) ||
-             (rj->data.srj->object==CONSTRAINTS && !dbt->object_to_export.no_constraint ))
+             (rj->data.srj->object==INDEXES && !dbt->object_to_import.no_index ) ||
+             (rj->data.srj->object==CONSTRAINTS && !dbt->object_to_import.no_constraint ))
            ){
         get_total_done(td->conf, &total);
           message("Thread %d: restoring %s %s.%s from %s. Tables %d of %d completed", td->thread_id,
@@ -281,7 +281,7 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
     case JOB_TO_CREATE_TABLE:
 
       dbt->schema_state=CREATING;
-      if ((!source_db || g_strcmp0(dbt->database->source_database,source_db)==0) && !no_schemas && !dbt->object_to_export.no_schema ){
+      if ((!source_db || g_strcmp0(dbt->database->source_database,source_db)==0) && !no_schemas && !dbt->object_to_import.no_schema ){
         if (serial_tbl_creation) g_mutex_lock(single_threaded_create_table);
         message("Thread %d: restoring table %s.%s from %s", td->thread_id,
                 dbt->database->target_database, dbt->source_table_name, rj->filename);
@@ -310,9 +310,9 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
               message("Skipping table or view %s.%s",
                 dbt->database->target_database, dbt->source_table_name);
               detailed_errors.skip_errors++;
-              dbt->object_to_export.no_data=TRUE;
-              dbt->object_to_export.no_index=TRUE;
-              dbt->object_to_export.no_constraint=TRUE;
+              dbt->object_to_import.no_data=TRUE;
+              dbt->object_to_import.no_index=TRUE;
+              dbt->object_to_import.no_constraint=TRUE;
             }else{
               g_atomic_int_inc(&(detailed_errors.schema_errors));
               if (purge_mode == FAIL)
@@ -362,7 +362,7 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
         if ( !no_schemas && (
              (rj->data.srj->object==TABLESPACE) ||
              (rj->data.srj->object==CREATE_DATABASE) ||
-             (rj->data.srj->object==VIEW && !dbt->object_to_export.no_view ) ||
+             (rj->data.srj->object==VIEW && !dbt->object_to_import.no_view ) ||
              (rj->data.srj->object==SEQUENCE) ||
              (rj->data.srj->object==TRIGGER) ||
              (rj->data.srj->object==POST)

--- a/src/myloader/myloader_table.c
+++ b/src/myloader/myloader_table.c
@@ -90,7 +90,7 @@ gboolean append_new_db_table( struct db_table **p_dbt, struct database *_databas
       dbt->rows_inserted=0;
       dbt->restore_job_list = NULL;
       dbt->restore_job_list_sorted = TRUE;  // Empty list is trivially sorted
-      parse_object_to_export(&(dbt->object_to_export),g_hash_table_lookup(conf_per_table.all_object_to_export, lkey));
+      parse_object_scope(&(dbt->object_to_import),g_hash_table_lookup(conf_per_table.all_object_to_import, lkey));
 			dbt->current_threads=0;
       dbt->max_threads=max_threads_per_table>num_threads?num_threads:max_threads_per_table;
       dbt->max_connections_per_job=0;

--- a/src/myloader/myloader_table.h
+++ b/src/myloader/myloader_table.h
@@ -27,7 +27,7 @@ struct db_table {
   gchar *source_table_name;
   gchar *table_filename;
   gchar *create_table_name;
-  struct object_to_export object_to_export;
+  struct object_scope object_to_import;
   guint64 rows;
   guint64 rows_inserted;
   GList * restore_job_list;

--- a/src/myloader/myloader_worker_loader_main.c
+++ b/src/myloader/myloader_worker_loader_main.c
@@ -77,7 +77,7 @@ static void enqueue_table_if_ready_locked(struct configuration *conf, struct db_
       dbt->count > 0 &&  // Perf: Use cached count instead of O(n) g_list_length()
       dbt->current_threads < dbt->max_threads &&
       !dbt->in_ready_queue &&
-      !dbt->object_to_export.no_data &&
+      !dbt->object_to_import.no_data &&
       !dbt->is_view &&
       !dbt->is_sequence) {
     dbt->in_ready_queue = TRUE;
@@ -99,7 +99,7 @@ gboolean give_me_next_data_job_conf(struct configuration *conf, struct restore_j
     if (dbt->schema_state == CREATED &&
         dbt->count > 0 &&  // Perf: Use cached count instead of O(n) g_list_length()
         dbt->current_threads < dbt->max_threads &&
-        !dbt->object_to_export.no_data &&
+        !dbt->object_to_import.no_data &&
         !dbt->is_view &&
         !dbt->is_sequence) {
       // Perf: Lazy sort before first access (O(n log n) once vs O(n²) insert_sorted)
@@ -171,7 +171,7 @@ gboolean give_me_next_data_job_conf(struct configuration *conf, struct restore_j
     }
 
     if (dbt->schema_state == CREATED && dbt->count > 0){  // Perf: Use cached count
-      if (dbt->object_to_export.no_data){
+      if (dbt->object_to_import.no_data){
         GList * current = dbt->restore_job_list;
         while (current){
           g_free(((struct restore_job *)current->data)->data.drj);


### PR DESCRIPTION
Previously, object_to_export was being used for mydumper and myloader which was confusing. Now, you can use object_to_import to identify what you want to import on the configured table. 