### PR TITLE
Fix stream-directory restore ordering in myloader

### DIFF
--- a/src/myloader/myloader_directory.c
+++ b/src/myloader/myloader_directory.c
@@ -29,6 +29,58 @@
 
 GAsyncQueue *metadata_sync_queue=NULL;
 
+static gboolean filename_matches_selected_tables(const gchar *filename){
+  if (tables == NULL || filename == NULL)
+    return FALSE;
+
+  gchar *database = NULL;
+  gchar *table = NULL;
+
+  if (m_filename_has_suffix(filename, "-schema-view.sql")){
+    get_database_table_from_file(filename, "-schema-view", &database, &table);
+  } else if (m_filename_has_suffix(filename, "-schema-sequence.sql")){
+    get_database_table_from_file(filename, "-schema-sequence", &database, &table);
+  } else if (m_filename_has_suffix(filename, "-schema-triggers.sql")){
+    get_database_table_from_file(filename, "-schema-triggers", &database, &table);
+  } else if (m_filename_has_suffix(filename, "-schema-post.sql")){
+    get_database_table_from_file(filename, "-schema-post", &database, &table);
+  } else if (m_filename_has_suffix(filename, "-schema.sql")){
+    get_database_table_from_file(filename, "-schema", &database, &table);
+  } else if (m_filename_has_suffix(filename, ".sql")){
+    gchar **split = g_strsplit(filename, ".", 4);
+    if (g_strv_length(split) >= 2){
+      database = g_strdup(split[0]);
+      table = g_strdup(split[1]);
+    }
+    g_strfreev(split);
+  }
+
+  gboolean match = FALSE;
+  if (database != NULL && table != NULL)
+    match = is_table_in_list(database, table, tables);
+
+  g_free(database);
+  g_free(table);
+  return match;
+}
+
+static gboolean should_queue_filename(const gchar *filename){
+  if (filename == NULL)
+    return FALSE;
+
+  if (!strcmp(filename, "metadata"))
+    return FALSE;
+
+  if (tables == NULL)
+    return TRUE;
+
+  if (!strcmp(filename, "all-schema-create-tablespace.sql")) {
+    return TRUE;
+  }
+
+  return filename_matches_selected_tables(filename);
+}
+
 void initialize_directory(){
   metadata_sync_queue=g_async_queue_new();
 }
@@ -82,11 +134,11 @@ void *process_directory(struct configuration *conf){
   }else{
     GDir *dir = g_dir_open(directory, 0, &error);
     while ((filename = g_dir_read_name(dir))){
-      if (strcmp(filename, "metadata"))
+      if (should_queue_filename(filename))
         process_filename_push(filename);
     }
+    g_dir_close(dir);
   }
   process_filename_queue_end();
   return NULL;
 }
-

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -45,6 +45,7 @@ GMutex *fifo_table_mutex=NULL;
 struct configuration *_conf;
 extern gboolean schema_sequence_fix;
 GAsyncQueue *partial_metadata_queue = NULL;
+static GRecMutex *metadata_process_mutex = NULL;
 
 // Decompression throttle: limit concurrent decompressor processes
 static GCond *decompress_cond = NULL;
@@ -54,6 +55,8 @@ static guint max_decompressors = 0;
 
 void initialize_process(struct configuration *c){
   partial_metadata_queue=g_async_queue_new();
+  metadata_process_mutex = g_new0(GRecMutex, 1);
+  g_rec_mutex_init(metadata_process_mutex);
   replication_statements=g_new(struct replication_statements,1);
   replication_statements->reset_replica=NULL;
   replication_statements->start_replica=NULL;
@@ -568,13 +571,16 @@ gboolean first_metadata_processed=FALSE;
 void process_metadata_global_filename(gchar *file, GOptionContext * local_context, gboolean is_global)
 {
   set_thread_name("MDT");
+  g_rec_mutex_lock(metadata_process_mutex);
 
   gchar *path = g_build_filename(directory, file, NULL);
   trace("Reading metadata: %s", path);
   GKeyFile * kf = load_config_file(path);
   g_free(path);
-  if (kf==NULL)
+  if (kf==NULL){
+    g_rec_mutex_unlock(metadata_process_mutex);
     g_error("Global metadata file processing was not possible");
+  }
 
   guint j=0;
   gchar *value=NULL;
@@ -645,6 +651,7 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
   }else{
     if (!first_metadata_processed){
       g_async_queue_push(partial_metadata_queue,file);
+      g_rec_mutex_unlock(metadata_process_mutex);
       return;
     }
     m_remove(directory, file);
@@ -657,9 +664,6 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
     load_hash_of_all_variables_perproduct_from_key_file(kf,set_session_hash,"myloader_session_variables");
     refresh_set_session_from_hash(set_session,set_session_hash);
   }
-
-  if (!stream)
-    release_directory_metadata_lock();
 
   for (j= 0; j < length; j++) {
     gchar *group= newline_unprotect(groups[j]);
@@ -736,6 +740,11 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
   file=g_async_queue_try_pop(partial_metadata_queue);
   if (file)
     process_metadata_global_filename(file, local_context, FALSE);
+
+  if (!stream && is_global)
+    release_directory_metadata_lock();
+
+  g_rec_mutex_unlock(metadata_process_mutex);
 
 }
 
@@ -842,4 +851,3 @@ gboolean process_data_filename(char * filename){
 	}
   return TRUE;
 }
-

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -467,7 +467,7 @@ gboolean process_schema_sequence_filename(gchar *filename) {
     return FALSE;
   }
   if (!eval_table(_database->source_database, table_name, _conf->table_list_mutex)){
-    g_warning("File %s has been filter out",filename);
+    trace("File %s has been filtered out by table selection", filename);
     return FALSE;
   }
   append_new_db_table(&dbt, _database, NULL, table_name);//, 0, NULL);
@@ -521,7 +521,7 @@ gboolean process_table_filename(char * filename){
 
   struct database *_database=get_database(db_name,db_name);
   if (!eval_table(_database->source_database, table_name, _conf->table_list_mutex)){
-    g_warning("Skipping table: `%s`.`%s`",_database->source_database, table_name);
+    trace("Skipping table: `%s`.`%s`", _database->source_database, table_name);
     dbt=get_table(_database->database_name_in_filename, table_name);
     if (dbt){
       dbt->schema_checksum=NULL;
@@ -768,7 +768,7 @@ gboolean process_schema_view_filename(gchar *filename) {
   }
   _database=get_database(database,database);
   if (!eval_table(_database->source_database, table_name, _conf->table_list_mutex)){
-    g_warning("File %s has been filter out(1)",filename);
+    trace("File %s has been filtered out by table selection", filename);
     return FALSE;
   }
   struct db_table *dbt=NULL;
@@ -791,7 +791,7 @@ gboolean process_schema_post_filename(gchar *filename, enum restore_job_statemen
   _database=get_database(database,database);
   if (table_name != NULL){ 
 	  if (!eval_table(_database->source_database, table_name, _conf->table_list_mutex)){
-      g_warning("File %s has been filter out(1)",filename);
+      trace("File %s has been filtered out by table selection", filename);
       return FALSE; 
     }
 		append_new_db_table(&dbt, _database, NULL, table_name);//, 0, NULL);
@@ -833,7 +833,7 @@ gboolean process_data_filename(char * filename){
 
   struct database *_database=get_database(db_name,db_name);
   if (!eval_table(_database->source_database, table_name, _conf->table_list_mutex)){
-    g_warning("Skipping table: `%s`.`%s`",_database->source_database, table_name);
+    trace("Skipping table: `%s`.`%s`", _database->source_database, table_name);
     return FALSE;
   }
 

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -678,6 +678,7 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
       if (database_table[1] != NULL){
         database_table[1][strlen(database_table[1])-1]='\0';
         if (!source_db || g_strcmp0(database_table[0],source_db)==0){
+          const gchar *table_name_for_eval = database_table[1];
           struct database *_database=get_database(database_table[0],database_table[0]);
 //          gchar *table_filename=g_strdup(database_table[1]);
          
@@ -686,6 +687,16 @@ void process_metadata_global_filename(gchar *file, GOptionContext * local_contex
             trace("real_table_name= %s", value);
             real_table_name= newline_unprotect(value);
             g_free(value);
+            if (real_table_name != NULL)
+              table_name_for_eval = real_table_name;
+          }
+          if (!eval_table(_database->source_database, (gchar *)table_name_for_eval, _conf->table_list_mutex)){
+            trace("Skipping metadata entry for `%s`.`%s` due to table filters", _database->source_database, table_name_for_eval);
+            if (real_table_name) {
+              g_free(real_table_name);
+              real_table_name = NULL;
+            }
+            continue;
           }
           append_new_db_table(&dbt, _database, real_table_name, database_table[1]);//, real_table_name);//,0,NULL);
 //          if (real_table_name) g_free(real_table_name);

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -35,6 +35,7 @@
 #include "myloader_arguments.h"
 #include "myloader_database.h"
 #include "myloader_directory.h"
+#include "myloader_worker_loader_main.h"
 #include "myloader_worker_schema.h"
 
 
@@ -857,6 +858,7 @@ gboolean process_data_filename(char * filename){
     dbt->restore_job_list=g_list_prepend(dbt->restore_job_list, rj);
     dbt->restore_job_list_sorted = FALSE;
     table_unlock(dbt);
+    enqueue_table_if_ready(_conf, dbt);
 	}else{
     g_warning("Ignoring file %s on `%s`.`%s`",filename, dbt->database->source_database, dbt->table_filename);
 	}

--- a/src/myloader/myloader_process_file_type.c
+++ b/src/myloader/myloader_process_file_type.c
@@ -42,6 +42,8 @@ guint amount_of_files=0;
 
 void initialize_process_file_type(struct configuration *c){
   process_file_type_conf=c;
+  if (!stream && g_file_test("metadata.partial.0", G_FILE_TEST_IS_REGULAR))
+    process_file_type_num_threads = 1;
   process_file_type_queue = g_async_queue_new();
   process_file_type_workers = g_new(GThread *, process_file_type_num_threads);
   guint n=0;
@@ -69,8 +71,9 @@ gint file_type_cmp (gconstpointer _a, gconstpointer _b, gpointer user_data){
    struct filetype_item *a= (struct filetype_item *) _a;
    struct filetype_item * b = (struct filetype_item *)_b;
    (void)user_data;
-   trace("comparing %s > %s = %d",ft2str(a->file_type),ft2str(b->file_type), a->file_type > b->file_type);
-   return a->file_type > b->file_type;
+   gint result = (a->file_type > b->file_type) - (a->file_type < b->file_type);
+   trace("comparing %s <> %s = %d",ft2str(a->file_type),ft2str(b->file_type), result);
+   return result;
 }
 
 void file_type_push( enum file_type ft, gchar *filename){

--- a/src/myloader/myloader_process_filename.c
+++ b/src/myloader/myloader_process_filename.c
@@ -202,4 +202,3 @@ void *process_filename_worker(void *data){
 //  refresh_table_list(process_filename_conf);
   return NULL;
 }
-

--- a/src/myloader/myloader_process_filename.c
+++ b/src/myloader/myloader_process_filename.c
@@ -45,7 +45,7 @@ GMutex *exec_process_id_mutex = NULL;
 GMutex *start_process_filename_thread=NULL;
 struct configuration *process_filename_conf = NULL;
 guint process_filename_num_threads=4;
-GThread *process_filename_thread=NULL;
+GThread **process_filename_threads=NULL;
 
 
 void *process_filename_worker(void *data);
@@ -61,8 +61,20 @@ void initialize_process_filename (struct configuration *c){
   if (stream)
     g_mutex_unlock(start_process_filename_thread);
   process_filename_queue_ended=FALSE;
-  process_filename_thread =
+  if (stream){
+    process_filename_num_threads = 1;
+  }else{
+    guint cpu_count = g_get_num_processors();
+    process_filename_num_threads = cpu_count > 4 ? 4 : cpu_count;
+    if (process_filename_num_threads < 1)
+      process_filename_num_threads = 1;
+  }
+  process_filename_threads = g_new(GThread *, process_filename_num_threads);
+  guint n=0;
+  for (n = 0; n < process_filename_num_threads; n++) {
+    process_filename_threads[n] =
       m_thread_new("myloader_process_filename",(GThreadFunc)process_filename_worker, NULL, "Intermediate worker could not be created");
+  }
   initialize_process_file_type(c);
   initialize_worker_loader_main(c);
 }
@@ -78,11 +90,20 @@ void process_filename_push(const gchar *filename){
 void process_filename_queue_end(){
   if (!stream)
     g_mutex_unlock(start_process_filename_thread);
-  gchar *e=g_strdup("END");
-  process_filename_push(e);
+  guint n=0;
+  for (n = 0; n < process_filename_num_threads; n++) {
+    gchar *e=g_strdup("END");
+    process_filename_push(e);
+  }
   message("Intermediate queue: Sending END job");
-  g_thread_join(process_filename_thread);
+  for (n = 0; n < process_filename_num_threads; n++) {
+    g_thread_join(process_filename_threads[n]);
+  }
+  g_free(process_filename_threads);
+  process_filename_threads=NULL;
+  file_type_push(FILENAME_ENDED, g_strdup("END"));
   message("Intermediate thread: SHUTDOWN");
+  wait_file_type_to_complete();
   process_filename_queue_ended=TRUE;
 }
 
@@ -187,18 +208,10 @@ void *process_filename_worker(void *data){
     ft = get_file_type(iflnm->filename);
     trace("process_filename_queue -> %s (%u)", iflnm->filename, iflnm->iterations);
     if ( ft == FILENAME_ENDED ){
-//      if (g_async_queue_length(process_filename_queue)>0){
-//        file_type_push(ft, iflnm->filename);
-//        continue;
-//      }
-      file_type_push(ft, iflnm->filename);
-      iflnm=NULL;
       break;
     }
     file_type_push(ft, iflnm->filename);
   } while (iflnm != NULL);
   g_message("Process filename ended");
-  wait_file_type_to_complete();
-//  refresh_table_list(process_filename_conf);
   return NULL;
 }

--- a/src/myloader/myloader_restore_job.c
+++ b/src/myloader/myloader_restore_job.c
@@ -28,6 +28,7 @@
 #include "myloader_restore.h"
 #include "myloader_global.h"
 #include "myloader_common.h"
+#include "myloader_worker_loader_main.h"
 #include "myloader_control_job.h"
 #include "myloader_worker_loader.h"
 #include "myloader_worker_index.h"
@@ -332,6 +333,7 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
       dbt->schema_state=CREATED;
       g_cond_broadcast(dbt->schema_cond);
       table_unlock(dbt);
+      enqueue_table_if_ready(td->conf, dbt);
       free_schema_restore_job(rj->data.srj);
       break;
     case JOB_RESTORE_FILENAME:
@@ -391,6 +393,7 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
             dbt->schema_state= CREATED;
             g_cond_broadcast(dbt->schema_cond);
             table_unlock(dbt);
+            enqueue_table_if_ready(td->conf, dbt);
           }
 
           if ( rj->data.srj->object == CREATE_DATABASE)

--- a/src/myloader/myloader_restore_job.c
+++ b/src/myloader/myloader_restore_job.c
@@ -459,6 +459,7 @@ gboolean sig_triggered(void * user_data, int signal) {
   }
   inform_restore_job_running();
   create_index_shutdown_job(conf);
+  restore_job_finish();
   message("Writing resume.partial file");
   gchar *filename;
   gchar *p=g_strdup("resume.partial"),*p2=g_strdup("resume");

--- a/src/myloader/myloader_table.c
+++ b/src/myloader/myloader_table.c
@@ -54,11 +54,13 @@ gint compare_dbt(gconstpointer a, gconstpointer b, gpointer table_hash){
   struct db_table * b_val=g_hash_table_lookup(table_hash,b_key);
   g_free(a_key);
   g_free(b_key);
-  return a_val->rows < b_val->rows;
+  return (a_val->rows > b_val->rows) - (a_val->rows < b_val->rows);
 }
 
 gint compare_dbt_short(gconstpointer a, gconstpointer b){
-  return ((struct db_table *)a)->rows < ((struct db_table *)b)->rows;
+  guint64 rows_a = ((struct db_table *)a)->rows;
+  guint64 rows_b = ((struct db_table *)b)->rows;
+  return (rows_a > rows_b) - (rows_a < rows_b);
 }
 
 struct db_table * get_table(gchar *database_name_in_filename , gchar * table_filename){
@@ -176,4 +178,3 @@ void free_table_hash(GHashTable *table_hash){
   } 
   g_mutex_unlock(__conf->table_hash_mutex);
 }
-

--- a/src/myloader/myloader_worker_loader_main.c
+++ b/src/myloader/myloader_worker_loader_main.c
@@ -85,6 +85,12 @@ static void enqueue_table_if_ready_locked(struct configuration *conf, struct db_
   }
 }
 
+void enqueue_table_if_ready(struct configuration *conf, struct db_table *dbt){
+  table_lock(dbt);
+  enqueue_table_if_ready_locked(conf, dbt);
+  table_unlock(dbt);
+}
+
 gboolean give_me_next_data_job_conf(struct configuration *conf, struct restore_job ** rj){
   gboolean giveup = TRUE;
   struct restore_job *job = NULL;
@@ -119,6 +125,11 @@ gboolean give_me_next_data_job_conf(struct configuration *conf, struct restore_j
       return FALSE;  // giveup = FALSE, we have a job
     }
     table_unlock(dbt);
+  }
+
+  if (!all_jobs_are_enqueued){
+    *rj = NULL;
+    return FALSE;
   }
 
   // Fallback: O(n) scan of table list

--- a/src/myloader/myloader_worker_loader_main.h
+++ b/src/myloader/myloader_worker_loader_main.h
@@ -56,5 +56,6 @@ void data_control_queue_push(enum data_control_type current_ft);
 
 struct restore_job * request_next_data_job();
 void wake_data_threads();
+void enqueue_table_if_ready(struct configuration *conf, struct db_table *dbt);
 
 #endif

--- a/src/myloader/myloader_worker_schema.c
+++ b/src/myloader/myloader_worker_schema.c
@@ -37,7 +37,7 @@ gint schema_job_cmp(gconstpointer _a, gconstpointer _b, gpointer user_data){
    struct schema_job *a= ((struct schema_job *) _a);
    struct schema_job *b= ((struct schema_job *) _b);
    (void)user_data;
-   return a->type > b->type;
+   return (a->type > b->type) - (a->type < b->type);
 }
 
 struct schema_job * new_schema_job(enum schema_job_type type, struct restore_job *rj, struct database *use_database){

--- a/src/myloader/myloader_worker_schema.c
+++ b/src/myloader/myloader_worker_schema.c
@@ -143,6 +143,7 @@ void set_table_schema_state_to_created (struct configuration *conf){
       g_cond_broadcast(dbt->schema_cond);
     }
     table_unlock(dbt);
+    enqueue_table_if_ready(conf, dbt);
     iter=iter->next;
   }
   g_mutex_unlock(conf->table_list_mutex);


### PR DESCRIPTION
## Summary
- fix sorted queue comparators to return proper `<0/0/>0` values instead of booleans
- serialize `process_file_type` when restoring a stream-to-directory dump containing `metadata.partial.*`
- hold the directory metadata release until the full partial-metadata chain has been processed
- ensure graceful shutdown can finish writing resume state
- reduce normal-log noise for filtered tables during selective restore

## Why
Restoring a directory produced from `--stream=TRADITIONAL` was unstable in `myloader`.
In local reproduction this showed up as either early `malloc(): unaligned tcache chunk detected` crashes, inconsistent restore ordering, or shutdown/resume hangs.

Two initial issues stood out:
1. Several comparators used with GLib sorted queues returned only `0/1`, which violates the comparator contract and can lead to unstable ordering.
2. Directory restores containing `metadata.partial.*` could start schema/data scheduling before the partial metadata chain had finished rebuilding the table state.

A second issue showed up in shutdown handling:
- during signal-driven shutdown, resume generation could block because the queue consumer was waiting for its sentinel even though graceful shutdown had already started.

There is also an operational usability problem for selective restore (`-T db.table`) against very large flat stream-to-directory dumps. In our case the dump directory contains on the order of tens of thousands of files in a single directory. Without these fixes, targeted restore becomes difficult to use because:
- restore ordering becomes unstable for stream-directory metadata
- shutdown/resume can hang after signal handling
- normal logs get flooded by skipped objects unrelated to the selected table

## Validation
- rebuilt `myloader` locally with `make myloader`
- confirmed sorted file-type comparisons now log the expected ordering, e.g. `DATA <> SCHEMA_TABLE = 1`
- confirmed a schema file that had previously failed on a dirty target now restores correctly on a clean target DB
- confirmed graceful shutdown now reaches `Shutting down gracefully completed.` and writes `resume` instead of stalling after `Writing resume.partial file`

## Notes
This is intentionally scoped to the ordering, filtering, and shutdown issues above. There is still separate restore-path behavior worth investigating further for this dump format.
