### PR TITLE
Release idle myloader connections during tail wait

### DIFF
--- a/src/myloader/myloader_restore.c
+++ b/src/myloader/myloader_restore.c
@@ -187,12 +187,30 @@ void wait_restore_threads_to_close(){
 }
 
 void reconnect_connection_data(struct connection_data *cd){
-  mysql_close(cd->thrconn);
+  if (cd->thrconn != NULL)
+    mysql_close(cd->thrconn);
   cd->thrconn=mysql_init(NULL);
   m_connect(cd->thrconn);
   cd->connection_id=mysql_thread_id(cd->thrconn);
   execute_use(cd);
   execute_gstring(cd->thrconn, set_session);
+}
+
+gboolean release_idle_connection_if_possible(){
+  struct connection_data *cd = g_async_queue_try_pop(connection_pool);
+  if (cd == NULL)
+    return FALSE;
+
+  if (cd->thrconn != NULL) {
+    trace("Closing idle connection: %ld", cd->connection_id);
+    mysql_close(cd->thrconn);
+    cd->thrconn = NULL;
+    cd->connection_id = 0;
+    cd->current_database = NULL;
+  }
+
+  g_async_queue_push(connection_pool, cd);
+  return TRUE;
 }
 
 int restore_data_in_gstring_by_statement(struct connection_data *cd, GString *data, gboolean is_schema, guint *query_counter)
@@ -235,6 +253,13 @@ int restore_data_in_gstring_by_statement(struct connection_data *cd, GString *da
 }
 
 void setup_connection(struct connection_data *cd, struct thread_data *td, struct io_restore_result *io_restore_result , gboolean start_transaction, struct database *use_database, GString *header){
+  if (cd->thrconn == NULL) {
+    cd->thrconn = mysql_init(NULL);
+    m_connect(cd->thrconn);
+    cd->connection_id = mysql_thread_id(cd->thrconn);
+    cd->current_database = NULL;
+    execute_gstring(cd->thrconn, set_session);
+  }
   trace("Thread %d: Connection %ld granted", td->thread_id, cd->connection_id);
   if (mysql_ping(cd->thrconn)) {
     g_warning("Thread %d: Connection %ld failed", td->thread_id, cd->connection_id);

--- a/src/myloader/myloader_restore.h
+++ b/src/myloader/myloader_restore.h
@@ -42,3 +42,4 @@ int restore_data_from_mydumper_file(struct thread_data *td, const char *filename
 void release_load_data_as_it_is_close( gchar * filename );
 void close_restore_thread();
 void wait_restore_threads_to_close();
+gboolean release_idle_connection_if_possible();

--- a/src/myloader/myloader_worker_loader_main.c
+++ b/src/myloader/myloader_worker_loader_main.c
@@ -285,6 +285,9 @@ void *worker_loader_main_thread(struct configuration *conf){
           }
           */
         }else{
+          if (all_jobs_are_enqueued) {
+            release_idle_connection_if_possible();
+          }
           trace("Thread will be waiting | all_jobs_are_enqueued: %d | giveup: %d", all_jobs_are_enqueued, giveup);
           g_mutex_lock(threads_waiting_mutex);
           if (threads_waiting<_num_threads)


### PR DESCRIPTION
## Summary
- release idle connections from the restore connection pool while loader workers are waiting near the tail of the restore
- lazily recreate a pooled `MYSQL` handle when that slot is borrowed again
- keep this isolated from the directory scan / scheduling work in #2223

## Why
During local restore tests, `myloader` kept most DB sessions open until the very end even when only a few loader workers still had work left.
This was visible in `PROCESSLIST` during selective restores of large tables and unnecessarily held DB resources for idle worker slots.

## Implementation
- add `release_idle_connection_if_possible()` to close one currently free pooled connection
- call it from the loader control path when all jobs are already enqueued, there is no immediate job to dispatch, and workers are entering wait state
- make `setup_connection()` recreate the `MYSQL` handle on demand when a previously released pooled slot is borrowed again

## Local verification
- verified a clean precondition before restore: no leftover `myloader` test processes and the target verification database was empty (`BASE TABLE` / `VIEW` / `TRIGGER` / `ROUTINE` / `EVENT` all zero)
- ran a selective restore of 10 large tables from a local dump directory
- used `-t 20 --max-threads-per-table 20`
- baseline `PROCESSLIST` at start was 2 total application sessions
- shortly after start it rose to 22 total sessions
- near the tail it dropped to 7 total sessions while restore was still running, confirming that idle pooled connections were being released

## Notes
This does not address the separate end-of-run behavior where interrupted restores can still leave long-running `ALTER TABLE` work after timeout/kill. That remains separate from this PR.
