### PR TITLE
Release idle myloader index-worker connections during shutdown wait

### DIFF
--- a/src/myloader/myloader_worker_index.c
+++ b/src/myloader/myloader_worker_index.c
@@ -23,12 +23,14 @@
 #include "myloader_worker_loader_main.h"
 #include "myloader_global.h"
 #include "myloader_database.h"
+#include "myloader_restore.h"
 #include "../logging.h"
 
 GAsyncQueue * optimize_keys_all_tables_queue=NULL;
 GThread **index_threads = NULL;
 struct thread_data *index_td = NULL;
 static GMutex *init_connection_mutex=NULL;
+#define INDEX_IDLE_WAIT_USEC G_USEC_PER_SEC
 void *worker_index_thread(struct thread_data *td);
 
 void initialize_worker_index(struct configuration *conf){
@@ -46,7 +48,13 @@ void initialize_worker_index(struct configuration *conf){
 }
 
 gboolean process_index(struct thread_data * td){
-  struct control_job *job=g_async_queue_pop(td->conf->index_queue);
+  /* Let idle index workers periodically drop pooled DB sessions while they wait
+   * for more index jobs or the final shutdown signal. */
+  struct control_job *job=g_async_queue_timeout_pop(td->conf->index_queue, INDEX_IDLE_WAIT_USEC);
+  if (job == NULL) {
+    release_idle_connection_if_possible();
+    return TRUE;
+  }
   if (job->type==JOB_SHUTDOWN)
   {
     trace("index_queue -> %s", jtype2str(job->type));


### PR DESCRIPTION
## Summary

Release idle myloader index-worker connections while the restore is waiting for the overall job to finish.

This extends the existing idle-connection handling that already exists for loader workers to the index rebuild phase.

## Problem

After an index worker finishes its last table, it can remain blocked on `index_queue` until the global shutdown job arrives.

During that wait, the worker is no longer doing useful work, but its pooled MySQL connection can stay open for the rest of the restore. On large restores this leaves unnecessary sleeping sessions in the database until the whole job completes.

## Fix

Index workers now poll `index_queue` with a short timeout instead of waiting forever in a blocking pop.

When the timeout expires and there is still no index job available, the worker calls `release_idle_connection_if_possible()` and then continues waiting. If more index work appears later, the existing connection setup path recreates the session on demand before executing the next statement.

This keeps the previous execution flow intact:

- active index jobs are processed exactly as before
- workers still exit only on `JOB_SHUTDOWN`
- only idle pooled connections are released

## Why this is safe

- `release_idle_connection_if_possible()` only operates on entries taken from `connection_pool`, so it only closes currently idle pooled connections
- `setup_connection()` already recreates a closed connection when `thrconn == NULL`, reapplies session settings, and switches to the required database before reuse
- the change does not alter index job ordering or shutdown semantics
