### PR TITLE
Add warning for deprecated --enable-binlog option

### DIFF
--- a/src/myloader/myloader_arguments.c
+++ b/src/myloader/myloader_arguments.c
@@ -122,6 +122,7 @@ gboolean arguments_callback(const gchar *option_name,const gchar *value, gpointe
     return TRUE;
   } else if (!g_strcmp0(option_name, "--enable-binlog") || !g_strcmp0(option_name, "-e")){
     m_warning("Option --enable-binlog / -e is discouraged. Use [myloader_session_variables] in the --defaults-file or --defaults-extra-file instead");
+    enable_binlog=TRUE;
     return TRUE;
   }
   


### PR DESCRIPTION
Warn users against using deprecated --enable-binlog option.