### PR TITLE
Fixing break in ignore_engines Check

### DIFF
--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -1224,7 +1224,6 @@ void dump_database_thread(MYSQL *conn, struct database *database) {
     if (dump && ignore_engines && !is_view && !is_sequence) {
       if (m_pstrstr(ignore_engines, row[ecol])){
         dump = 0;
-        break;
       }
     }
 


### PR DESCRIPTION
Caused abandonment of table enumeration for the entire database on the first match of an exclusion rule