### PR TITLE
Adding --skip-create-table, fix split table rule and --throttle logic

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -147,28 +147,34 @@ void parse_key_file_group(GKeyFile *kf, GOptionContext *context, const gchar * g
     g_error("Loading configuration on section %s: %s",group,error->message);
   }else{
     // Transform the key-value pair to parameters option that the parsing will understand
+    GString *new_list=g_string_sized_new(50);
     for (i=0; i < len; i++){
+
       if (g_strcmp0("host",keys[i]) && g_strcmp0("user",keys[i]) && g_strcmp0("password",keys[i])){
         list = g_slist_append(list, g_strdup_printf("--%s",keys[i]));
-        gchar *value=g_key_file_get_value(kf,group,keys[i],&error);
-        if ( value != NULL ) list=g_slist_append(list, value);
+        g_string_append_printf(new_list, "--%s",keys[i]);
+        gchar *value=g_strdup(g_key_file_get_value(kf,group,keys[i],&error));
+        if ( value != NULL ) list=g_slist_append(list, g_strdup(value));
       }
     }
-    gint slen = g_slist_length(list) + 1;
+    gint slen = g_slist_length(list) + 2;
     gchar ** gclist = g_new0(gchar *, slen);
     GSList *ilist=list;
     gint j=0;
-    for (j=1; j < slen ; j++){
-      gclist[j]=ilist->data;
+    gclist[j]=g_strdup(group);
+    for (j=1; j < slen -1 ; j++){
+      gclist[j]=g_strdup(ilist->data);
       ilist=ilist->next;
     }
-    g_slist_free(list);
+    gclist[j]=NULL;
+    g_option_context_set_ignore_unknown_options(context, TRUE);
     // Second parse over the options
-    if (!g_option_context_parse(context, &slen, &gclist, &error)) {
+    if (!g_option_context_parse_strv(context, &gclist, &error)) {
       m_critical("option parsing failed: %s, try --help\n", error->message);
     }else{
       trace("Config file loaded");
     }
+//    g_slist_free(list);
     g_strfreev(gclist);
   }
   g_strfreev(keys);

--- a/src/common_options.c
+++ b/src/common_options.c
@@ -129,13 +129,22 @@ gboolean common_arguments_callback(const gchar *option_name,const gchar *value, 
       }else{
         tp=g_strsplit(value, "=", 2);
       }
-      throttle_variable=g_strdup(tp[0]);
-      throttle_value = atoi(tp[1]);
+      guint len=g_strv_length(tp);
+      if (len>2){
+        m_error("Error parsing --throttle with: %s. You should use for instance 20:Threads_running=10, where 20 indicates the microseconds waiting, then the variable and max allowed value to start throttling", value);
+      }
+      if (len > 1){
+        throttle_variable=g_strdup(tp[0]);
+        throttle_value = atoi(tp[1]);
+      }else{
+        throttle_variable=g_strdup("Threads_running");
+        throttle_value = atoi(tp[0]);
+      }
       g_strfreev(tq);
       g_strfreev(tp);
     }else{
       throttle_variable=g_strdup("Threads_running");
-      throttle_value = 0;
+      throttle_value = 4;
     }
     return TRUE;
   } else if (!strcmp(option_name, "--optimize-keys-engines")){
@@ -205,7 +214,7 @@ GOptionEntry common_entries[] = {
     {"dry-run", 0, 0, G_OPTION_ARG_NONE, &dry_run,
       "In dry-run mode, it skips the connection to the database and the execution of any query", NULL},
     {"throttle", 0, G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK, &common_arguments_callback,
-      "Expects a string like Threads_running=10. It will check the SHOW GLOBAL STATUS and if it is higher, it will increase the sleep time between SELECT. "
+      "Expects a string like 20:Threads_running=10, where 20 indicates the microseconds waiting, then the variable and max allowed value to start throttling. It will check the SHOW GLOBAL STATUS and if it is higher, it will increase the sleep time between SELECT. "
       "If option is used without parameters it will use Threads_running and the amount of threads", NULL},
     {NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL}};
 

--- a/src/myloader/myloader.c
+++ b/src/myloader/myloader.c
@@ -62,6 +62,7 @@ gboolean optimize_keys_all_tables = FALSE;
 gboolean kill_at_once = FALSE;
 gboolean enable_binlog = FALSE;
 gboolean disable_redo_log = FALSE;
+gboolean skip_create_table = FALSE;
 gboolean skip_triggers = FALSE;
 gboolean skip_constraints = FALSE;
 gboolean skip_indexes = FALSE;
@@ -201,6 +202,7 @@ void print_help(){
 
   print_list("regex",regex_list, NULL);
   print_string("source-db",source_db);
+  print_bool("skip-create-table",skip_create_table);
   print_bool("skip-triggers",skip_triggers);
   print_bool("skip-post",skip_post);
   print_bool("skip-constraints",skip_constraints);

--- a/src/myloader/myloader_arguments.c
+++ b/src/myloader/myloader_arguments.c
@@ -186,7 +186,7 @@ static GOptionEntry execution_entries[] = {
       "Options: AFTER_IMPORT_PER_TABLE, AFTER_IMPORT_ALL_TABLES and SKIP. Default: AFTER_IMPORT_PER_TABLE", NULL},
     {"optimize-keys-batchsize", 0, 0, G_OPTION_ARG_INT, &optimize_keys_batchsize,
       "Limits the amount of indexes per ALTER TABLE statement that adds the indexes, defaults: 0 (unlimited)", NULL},
-    {"no-schema", 0, 0, G_OPTION_ARG_NONE, &no_schemas, 
+    {"no-schemas", 0, 0, G_OPTION_ARG_NONE, &no_schemas, 
       "Do not import table schemas and triggers ", NULL},
     { "disable-redo-log", 0, 0, G_OPTION_ARG_NONE, &disable_redo_log,
       "Disables the REDO_LOG and enables it after, doesn't check initial status", NULL },
@@ -220,6 +220,8 @@ static GOptionEntry execution_entries[] = {
 static GOptionEntry filter_entries[] ={
     {"source-db", 's', 0, G_OPTION_ARG_STRING, &source_db,
      "Database to restore", NULL},
+    {"skip-create-table", 0, 0, G_OPTION_ARG_NONE, &skip_create_table,
+      "Do not execute the CREATE TABLE statement. By default, it executes the CREATE TABLE statement", NULL},
     {"skip-triggers", 0, 0, G_OPTION_ARG_NONE, &skip_triggers,
       "Do not import triggers. By default, it imports triggers", NULL},
     {"skip-post", 0, 0, G_OPTION_ARG_NONE, &skip_post,

--- a/src/myloader/myloader_global.h
+++ b/src/myloader/myloader_global.h
@@ -49,6 +49,7 @@ extern gboolean shutdown_triggered;
 extern gboolean skip_definer;
 extern gchar *replace_definer;
 extern gboolean skip_post;
+extern gboolean skip_create_table;
 extern gboolean skip_triggers;
 extern gboolean skip_constraints;
 extern gboolean skip_indexes;

--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -294,6 +294,7 @@ regex_error:
         if (optimize_keys || skip_constraints || skip_indexes ){
           GString *alter_table_statement=g_string_sized_new(512);
           GString *alter_table_constraint_statement=g_string_sized_new(512);
+          g_string_set_size(alter_table_statement,0);
           // Check if it is a /*!40  SET
           if (g_strrstr(data->str,"/*!40")){
             if (!should_ignore_set_statement(data)){
@@ -303,9 +304,11 @@ regex_error:
           }else{
             // Processing CREATE TABLE statement
             int flag = // process_create_table_statement(data->str, create_table_statement, alter_table_statement, alter_table_constraint_statement, dbt, (dbt->rows == 0 || dbt->rows >= 1000000 || skip_constraints || skip_indexes));
-                      global_process_create_table_statement(data->str, create_table_statement, alter_table_statement, alter_table_constraint_statement, dbt->source_table_name?dbt->source_table_name:dbt->create_table_name, (dbt->rows == 0 || dbt->rows >= 10 || skip_constraints || skip_indexes));
+                      global_process_create_table_statement(data->str, create_table_statement, alter_table_statement, alter_table_constraint_statement, dbt->source_table_name?dbt->source_table_name:dbt->create_table_name, TRUE );
             if (flag & IS_TRX_TABLE){
+              trace("IS_TRX_TABLE: %s.%s",dbt->database->target_database,dbt->source_table_name);
               if (flag & IS_ALTER_TABLE_PRESENT){
+                trace("IS_ALTER_TABLE_PRESENT: %s.%s",dbt->database->target_database,dbt->source_table_name);
 //                finish_alter_table(alter_table_statement);
                 g_message("Fast index creation will be used for table: %s.%s",dbt->database->target_database,dbt->source_table_name);
               }else{
@@ -313,10 +316,11 @@ regex_error:
                 alter_table_statement=NULL;
               }
 //              g_string_append(create_table_statement,g_strjoinv("\n)",g_strsplit(new_create_table_statement->str,",\n)",-1)));
-              if (!skip_indexes){
-                if (optimize_keys)
+              if (!skip_indexes && alter_table_statement!=NULL){
+                if (optimize_keys){
                   dbt->indexes=alter_table_statement;
-                else if (alter_table_statement!=NULL)
+                  trace("Index for table %s %s will be %s", dbt->database->target_database,dbt->source_table_name, dbt->indexes->str);
+                }else
                   g_string_append(create_table_statement,alter_table_statement->str);
               }
               if (!skip_constraints && (flag & INCLUDE_CONSTRAINT)){

--- a/src/myloader/myloader_restore_job.c
+++ b/src/myloader/myloader_restore_job.c
@@ -335,7 +335,7 @@ int process_restore_job(struct thread_data *td, struct restore_job *rj){
     case JOB_TO_CREATE_TABLE:
 
       dbt->schema_state=CREATING;
-      if ((!source_db || g_strcmp0(dbt->database->source_database,source_db)==0) && !no_schemas && !dbt->object_to_import.no_schema ){
+      if ((!source_db || g_strcmp0(dbt->database->source_database,source_db)==0) && !no_schemas && !skip_create_table && !dbt->object_to_import.no_schema){
         if (max_threads_for_schema_creation==1) g_mutex_lock(single_threaded_create_table);
         if (machine_log_json) {
           gchar *thread_id = g_strdup_printf("%u", td->thread_id);

--- a/test/specific_28/myloader.cnf
+++ b/test/specific_28/myloader.cnf
@@ -1,4 +1,4 @@
 [myloader]
 threads=4
-no-schema
+no-schemas
 directory=/tmp/data


### PR DESCRIPTION
Related to #2272 which I tested with:
```
./myloader -M -d data -v 4 --max-threads-for-schema-creation=1 --no-data --drop-database -B sakila2 --skip-constraints --skip-indexes ; 
./myloader -M -d data -v 4 --max-threads-for-schema-creation=1 --drop-table=NONE --skip-create-table -B sakila2
```