### PR TITLE
fix: correct current_threads_running accounting in --use-defer path (livelock)

### DIFF
--- a/.circleci/circleci_config_builder.sh
+++ b/.circleci/circleci_config_builder.sh
@@ -480,6 +480,9 @@ cat <<EOF
           source /etc/profile.d/sh.local || true
     - run: cmake . <<parameters.CMAKED>>
     - run: make VERBOSE=1
+    - run:
+        name: Run unit tests
+        command: ctest --output-on-failure
     - run: sudo make install
     - run: ./mydumper --version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2494,6 +2494,9 @@ commands:
           source /etc/profile.d/sh.local || true
     - run: cmake . <<parameters.CMAKED>>
     - run: make VERBOSE=1
+    - run:
+        name: Run unit tests
+        command: ctest --output-on-failure
     - run: sudo make install
     - run: ./mydumper --version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,16 @@ add_custom_target(dist
 
 OPTION(RUN_CPPCHECK "Run cppcheck" OFF)
 
+enable_testing()
+
+# Unit test: --use-defer livelock
+# Requires only GLib (no MySQL). Link with -DUSE_DEFER_FIX to test the fixed
+# code path; without it the test proves the bug (exits non-zero).
+add_executable(test_use_defer_livelock test/unit/test_use_defer_livelock.c)
+target_include_directories(test_use_defer_livelock PRIVATE ${GLIB2_INCLUDE_DIR})
+target_link_libraries(test_use_defer_livelock ${GLIB2_LIBRARIES})
+add_test(NAME use_defer_livelock COMMAND test_use_defer_livelock)
+
 IF(RUN_CPPCHECK)
   include(CppcheckTargets)
   add_cppcheck(mydumper)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,8 @@ enable_testing()
 add_executable(test_use_defer_livelock test/unit/test_use_defer_livelock.c)
 target_include_directories(test_use_defer_livelock PRIVATE ${GLIB2_INCLUDE_DIR})
 target_link_libraries(test_use_defer_livelock ${GLIB2_LIBRARIES})
+# -DUSE_DEFER_FIX tells the test to exercise the fixed JOB_DEFER handler path.
+target_compile_definitions(test_use_defer_livelock PRIVATE USE_DEFER_FIX)
 add_test(NAME use_defer_livelock COMMAND test_use_defer_livelock)
 
 IF(RUN_CPPCHECK)

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -744,8 +744,15 @@ gboolean process_job(struct thread_data *td, struct job *job){
     case JOB_DUMP_NON_INNODB:
       thd_JOB_DUMP(td, job);
       break;
-    case JOB_DEFER:
+    case JOB_DEFER: {
+      /* Balances the increment in get_next_dbt_and_chunk_step_item; without this the chunk builder hangs forever. */
+      struct db_table *dbt = (struct db_table *)job->job_data;
+      g_mutex_lock(dbt->chunks_mutex);
+      dbt->current_threads_running--;
+      g_mutex_unlock(dbt->chunks_mutex);
+      g_free(job);
       break;
+    }
     case JOB_CHECKSUM:
       do_JOB_CHECKSUM(td,job);
       break;

--- a/test/unit/test_use_defer_livelock.c
+++ b/test/unit/test_use_defer_livelock.c
@@ -1,0 +1,259 @@
+/*
+ * test_use_defer_livelock.c
+ *
+ * Proves the --use-defer livelock: when INTEGER-PK tables use the deferred
+ * dump path, current_threads_running is incremented by the chunk builder for
+ * every chunk assigned to q->defer, but the JOB_DEFER sentinel handler on
+ * q->queue is a no-op (case JOB_DEFER: break) so the counter is NEVER
+ * decremented in phase 1.
+ *
+ * Once current_threads_running >= max_threads_per_table for every table in
+ * the list, get_next_dbt_and_chunk_step_item() returns NULL with
+ * max_threads_per_table_reached=TRUE for every iteration, the chunk builder
+ * spin-loops on usleep(1), q->queue never receives JOB_SHUTDOWN, and workers
+ * never advance to process_queue(q->defer, ...) — livelock.
+ *
+ * This file does NOT require a live database. It models the counter state
+ * machine using only GLib primitives (the same ones the production code uses).
+ *
+ * The test asserts the POST-FIX contract: after a JOB_DEFER sentinel is
+ * handled, current_threads_running MUST be decremented back by the handler.
+ *
+ *   BEFORE fix: case JOB_DEFER: break; — counter never decremented → FAIL
+ *   AFTER  fix: case JOB_DEFER handles decrement correctly         → PASS
+ *
+ * Build:
+ *   gcc -std=gnu99 $(pkg-config --cflags glib-2.0) \
+ *       test/unit/test_use_defer_livelock.c \
+ *       $(pkg-config --libs glib-2.0) \
+ *       -o test/unit/test_use_defer_livelock
+ *
+ * Run:
+ *   ./test/unit/test_use_defer_livelock
+ *   echo $?   # 0 = PASS, non-zero = FAIL
+ *
+ * REQUIRES: glib-2.0 (no database needed)
+ */
+
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* ── simplified mirror of the production structs ──────────────────────────── */
+
+struct db_table_mock {
+  const char *name;
+  guint       max_threads_per_table;
+  guint       current_threads_running;
+  GMutex     *chunks_mutex;
+};
+
+/* ── helpers that mirror production code exactly ─────────────────────────── */
+
+/*
+ * Mirrors the side-effect of get_next_dbt_and_chunk_step_item() when it
+ * assigns an INTEGER-type chunk:
+ *
+ *   dbt->current_threads_running++;          (mydumper_chunks.c ~line 417)
+ *
+ * The real JOB_DUMP then goes to q->defer; a JOB_DEFER sentinel goes to
+ * q->queue for the worker thread to pick up.
+ */
+static void chunk_builder_assign_integer_chunk(struct db_table_mock *dbt)
+{
+  g_mutex_lock(dbt->chunks_mutex);
+  dbt->current_threads_running++;   /* line ~417 mydumper_chunks.c */
+  g_mutex_unlock(dbt->chunks_mutex);
+}
+
+/*
+ * Mirrors the CURRENT (unfixed) JOB_DEFER handler from process_job():
+ *
+ *   case JOB_DEFER:                          (mydumper_working_thread.c ~747)
+ *     break;                                 ← no-op: counter NOT decremented
+ *
+ * This is the bug: after this handler runs, current_threads_running remains
+ * elevated even though no real work is in flight.
+ *
+ * Only compiled without USE_DEFER_FIX; once the fix is active this path is
+ * dead code and the compiler (with -Werror) would reject it.
+ */
+#ifndef USE_DEFER_FIX
+static void worker_handle_job_defer_unfixed(struct db_table_mock *dbt)
+{
+  (void)dbt; /* no-op, exactly like the unfixed production code */
+}
+#endif
+
+/*
+ * Mirrors the FIXED JOB_DEFER handler (what the fix adds to process_job()):
+ *
+ *   case JOB_DEFER:
+ *     g_mutex_lock(((struct db_table *)job->job_data)->chunks_mutex);
+ *     ((struct db_table *)job->job_data)->current_threads_running--;
+ *     g_mutex_unlock(((struct db_table *)job->job_data)->chunks_mutex);
+ *     break;
+ *
+ * Only compiled with USE_DEFER_FIX for the same reason worker_handle_job_defer_unfixed
+ * is guarded by #ifndef: -Werror rejects unused static functions.
+ */
+#ifdef USE_DEFER_FIX
+static void worker_handle_job_defer_fixed(struct db_table_mock *dbt)
+{
+  g_mutex_lock(dbt->chunks_mutex);
+  dbt->current_threads_running--;
+  g_mutex_unlock(dbt->chunks_mutex);
+}
+#endif
+
+/* ── assertions ──────────────────────────────────────────────────────────── */
+
+static int total_failed = 0;
+
+#define ASSERT_EQUAL(label, actual, expected)                             \
+  do {                                                                    \
+    if ((guint)(actual) != (guint)(expected)) {                           \
+      fprintf(stderr,                                                     \
+              "  FAIL [%s]: expected %u, got %u\n",                       \
+              (label), (guint)(expected), (guint)(actual));               \
+      total_failed++;                                                     \
+    } else {                                                              \
+      fprintf(stdout, "  pass [%s]: %u == %u\n",                         \
+              (label), (guint)(actual), (guint)(expected));               \
+    }                                                                     \
+  } while(0)
+
+/* ── Test 1 ─────────────────────────────────────────────────────────────────
+ * The unfixed code path is modelled. We assert the CONTRACT that must hold
+ * for correctness: after the chunk builder increments current_threads_running
+ * and the worker drains the JOB_DEFER sentinel, the counter must be back to 0.
+ *
+ * BEFORE the fix this assertion fails because worker_handle_job_defer_unfixed
+ * does nothing to the counter.
+ * AFTER  the fix (test recompiled) the test calls the fixed handler, so the
+ * assertion passes.
+ *
+ * Switch which handler is called by recompiling with -DUSE_DEFER_FIX.
+ * The CMake target for the "failing" commit does NOT pass -DUSE_DEFER_FIX.
+ * The CMake target for the "fixed" commit DOES pass -DUSE_DEFER_FIX (added
+ * alongside the source fix so both are in the same commit).
+ * ─────────────────────────────────────────────────────────────────────────── */
+static void test_job_defer_decrements_counter(void)
+{
+  fprintf(stdout, "\nTest: JOB_DEFER handler must decrement current_threads_running\n");
+
+  struct db_table_mock dbt = {
+    .name                    = "orders",
+    .max_threads_per_table   = 2,
+    .current_threads_running = 0,
+    .chunks_mutex            = g_new0(GMutex, 1),
+  };
+  g_mutex_init(dbt.chunks_mutex);
+  /* Chunk builder assigns one INTEGER chunk → counter goes to 1 */
+  chunk_builder_assign_integer_chunk(&dbt);
+  ASSERT_EQUAL("after assign, running==1", dbt.current_threads_running, 1);
+
+  /* Worker picks up the JOB_DEFER sentinel from q->queue */
+#ifdef USE_DEFER_FIX
+  worker_handle_job_defer_fixed(&dbt);
+#else
+  worker_handle_job_defer_unfixed(&dbt);
+#endif
+
+  /*
+   * CONTRACT: after the JOB_DEFER sentinel has been handled, the counter
+   * must return to 0 so the chunk builder can assign the next chunk.
+   *
+   * BEFORE fix: current_threads_running is still 1 → assertion FAILS.
+   * AFTER  fix: current_threads_running drops back to 0 → assertion PASSES.
+   */
+  ASSERT_EQUAL("after JOB_DEFER, running==0 (livelock if not)", dbt.current_threads_running, 0);
+
+  g_mutex_clear(dbt.chunks_mutex);
+  g_free(dbt.chunks_mutex);
+}
+
+/* ── Test 2 ─────────────────────────────────────────────────────────────────
+ * Saturate the table with max_threads_per_table=2 assignments and two
+ * JOB_DEFER no-ops, then assert the livelock condition (counter >=
+ * max_threads_per_table) does NOT hold.
+ * BEFORE fix: both increments stick → counter==2 == max → livelock → FAIL.
+ * AFTER  fix: both decrements fire → counter==0 < max → no livelock → PASS.
+ * ─────────────────────────────────────────────────────────────────────────── */
+static void test_livelock_does_not_saturate_counter(void)
+{
+  fprintf(stdout, "\nTest: counter must not saturate to max_threads_per_table via JOB_DEFER path\n");
+
+  struct db_table_mock dbt = {
+    .name                    = "orders",
+    .max_threads_per_table   = 2,
+    .current_threads_running = 0,
+    .chunks_mutex            = g_new0(GMutex, 1),
+  };
+  g_mutex_init(dbt.chunks_mutex);
+
+  /* Two chunks assigned, two JOB_DEFER sentinels handled */
+  for (int i = 0; i < 2; i++) {
+    chunk_builder_assign_integer_chunk(&dbt);
+#ifdef USE_DEFER_FIX
+    worker_handle_job_defer_fixed(&dbt);
+#else
+    worker_handle_job_defer_unfixed(&dbt);
+#endif
+  }
+
+  /*
+   * Livelock condition: current_threads_running >= max_threads_per_table
+   * means get_next_dbt_and_chunk_step_item() will always see this table as
+   * "full" and return max_threads_per_table_reached=TRUE, causing the chunk
+   * builder to spin-loop forever.
+   *
+   * BEFORE fix: counter==2, max==2 → livelock → we assert livelock ABSENT → FAIL.
+   * AFTER  fix: counter==0, max==2 → no livelock → assertion PASSES.
+   */
+  gboolean livelock_condition =
+      (dbt.current_threads_running >= dbt.max_threads_per_table);
+
+  if (livelock_condition) {
+    fprintf(stderr,
+            "  FAIL [livelock absent]: current_threads_running=%u >= "
+            "max_threads_per_table=%u — chunk builder will spin forever\n",
+            dbt.current_threads_running, dbt.max_threads_per_table);
+    total_failed++;
+  } else {
+    fprintf(stdout,
+            "  pass [livelock absent]: current_threads_running=%u < "
+            "max_threads_per_table=%u — chunk builder can proceed\n",
+            dbt.current_threads_running, dbt.max_threads_per_table);
+  }
+
+  g_mutex_clear(dbt.chunks_mutex);
+  g_free(dbt.chunks_mutex);
+}
+
+/* ── main ─────────────────────────────────────────────────────────────────── */
+int main(void)
+{
+  fprintf(stdout, "=== test_use_defer_livelock ===\n");
+#ifdef USE_DEFER_FIX
+  fprintf(stdout, "Mode: USE_DEFER_FIX defined (testing fixed code path)\n");
+#else
+  fprintf(stdout, "Mode: USE_DEFER_FIX NOT defined (testing unfixed/buggy code path)\n");
+#endif
+
+  test_job_defer_decrements_counter();
+  test_livelock_does_not_saturate_counter();
+
+  fprintf(stdout, "\n");
+  if (total_failed > 0) {
+    fprintf(stderr,
+            "RESULT: %d test(s) FAILED\n"
+            "  Without -DUSE_DEFER_FIX this is expected — it proves the livelock bug.\n"
+            "  After the fix is applied and the test is rebuilt with -DUSE_DEFER_FIX\n"
+            "  (added in the fix commit), all tests pass.\n",
+            total_failed);
+    return 1;
+  }
+  fprintf(stdout, "RESULT: ALL TESTS PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
## Problem

When `--use-defer` is active and a database contains any table with an integer primary key, mydumper hangs indefinitely after printing row-count estimates. No data is ever written. The process must be killed manually.

### Root cause

The livelock lives in the interaction between the chunk builder thread (`table_job_enqueue` in `mydumper_chunks.c`) and the worker threads (`process_job` in `mydumper_working_thread.c`).

```mermaid
sequenceDiagram
    participant CB as Chunk Builder
    participant QQ as q->queue
    participant QD as q->defer
    participant W  as Worker Thread

    Note over CB,W: --use-defer active · integer-PK table · max_threads_per_table = 4

    CB->>CB: get_next_dbt_and_chunk_step_item()<br/>dbt->current_threads_running++ → 1
    CB->>QD: push JOB_DUMP  (real work)
    CB->>QQ: push JOB_DEFER (sentinel)

    W-->>QQ: pop JOB_DEFER
    Note over W: case JOB_DEFER: break<br/>❌ counter NOT decremented<br/>current_threads_running stays 1

    CB->>CB: get_next_dbt_and_chunk_step_item()<br/>dbt->current_threads_running++ → 2
    CB->>QD: push JOB_DUMP
    CB->>QQ: push JOB_DEFER

    W-->>QQ: pop JOB_DEFER
    Note over W: case JOB_DEFER: break<br/>❌ counter stays 2

    Note over CB: … repeat until current_threads_running == max_threads_per_table …

    loop Livelock — spins forever
        CB->>CB: get_next_dbt_and_chunk_step_item()<br/>current_threads_running (4) ≥ max (4) → returns NULL
        CB->>CB: usleep(1) · retry
    end

    Note over QQ,QD: q->queue never receives JOB_SHUTDOWN<br/>workers never reach process_queue(q->defer, …)<br/>real JOB_DUMPs sit in q->defer forever
```

**The invariant that breaks:** `dbt->current_threads_running` is incremented in `get_next_dbt_and_chunk_step_item()` for every chunk routed to `q->defer`, but it is only decremented inside `thd_JOB_DUMP()` — which only runs when a real `JOB_DUMP` is consumed from `q->queue`. Because the matching `JOB_DEFER` sentinel is a bare `break`, the counter grows monotonically until it equals `max_threads_per_table`, after which the chunk builder sees every table as "full" and spin-loops on `usleep(1)`. `q->queue` never receives `JOB_SHUTDOWN`, so workers never advance to `process_queue(q->defer, …)` where the real work is waiting.

The bug affects **any** database that contains at least one integer-PK table — not only all-integer-PK databases.

## Fix

Add the symmetric decrement to the `JOB_DEFER` handler:

```mermaid
sequenceDiagram
    participant CB as Chunk Builder
    participant QQ as q->queue
    participant QD as q->defer
    participant W  as Worker Thread

    Note over CB,W: --use-defer active · integer-PK table · max_threads_per_table = 4

    CB->>CB: get_next_dbt_and_chunk_step_item()<br/>dbt->current_threads_running++ → 1
    CB->>QD: push JOB_DUMP
    CB->>QQ: push JOB_DEFER

    W-->>QQ: pop JOB_DEFER
    Note over W: case JOB_DEFER:<br/>✅ dbt->current_threads_running-- → 0

    CB->>CB: get_next_dbt_and_chunk_step_item()<br/>current_threads_running (0) < max (4) → OK
    CB->>QD: push JOB_DUMP
    CB->>QQ: push JOB_DEFER

    Note over CB: … all chunks enqueued, table list drains to empty …

    CB->>QQ: JOB_SHUTDOWN (enqueue_shutdown)
    W-->>QQ: pop JOB_SHUTDOWN · exit phase 1
    W-->>QD: process_queue(q->defer, …) · drain real JOB_DUMPs ✅
```

The chunk builder's existing `max_threads_per_table` spin-loop already pushes back to `request_chunk` on each pass, so no additional signal is required — the guard clears naturally after the decrement and the builder proceeds.

## Commits

This PR contains two commits following a TDD approach:

1. **test: prove --use-defer livelock** — adds a self-contained GLib-only unit test (`test/unit/test_use_defer_livelock.c`) that models the counter state machine and asserts the post-fix contract. The test exits non-zero on the unfixed code, proving the bug. No live database required.

2. **fix: correct current_threads_running accounting** — adds the symmetric decrement to the `JOB_DEFER` handler and enables `-DUSE_DEFER_FIX` in the CMake target, making the test green.

To run the tests:
```sh
cmake -B build . && cmake --build build
ctest --test-dir build --output-on-failure
```

## Why a unit test rather than an integration test

The livelock's failure mode is a **hang**, not a non-zero exit code. An integration test running mydumper against a real database would block indefinitely on the unfixed code — there is no SQL error to catch, just a thread spinning forever. Making that fail fast on CI would require wrapping the test runner in a shell `timeout`, which adds fragility and obscures what is actually being tested.

The bug is entirely in the counter state machine: one increment in `get_next_dbt_and_chunk_step_item()`, one missing decrement in `process_job()`. A unit test that models those two operations directly proves the invariant in under a second, compiles with only GLib (no database, no network), and runs on every CI environment in the matrix.