### PR TITLE
Fixing SAFE_NO_LOCK bug

### DIFF
--- a/src/mydumper/mydumper_start_dump.c
+++ b/src/mydumper/mydumper_start_dump.c
@@ -1009,6 +1009,31 @@ cleanup:
     mysql_free_result(slave);
 }
 
+static
+void get_binlog_position(MYSQL *conn, char **masterlog, char **masterpos, char **mastergtid){
+  trace("Getting binary log position");
+  struct M_ROW *mr = m_store_result_row(conn, show_binary_log_status, m_warning, m_message, "Couldn't get master position", NULL);
+  if ( mr->row ) {
+    *masterlog = g_strdup(mr->row[0]);
+    *masterpos = g_strdup(mr->row[1]);
+    // Oracle/Percona GTID
+    if (mysql_num_fields(mr->res) == 5) {
+      *mastergtid = g_strdup(remove_new_line(mr->row[4]));
+    } else {
+      // Let's try with MariaDB 10.x
+      // Use gtid_binlog_pos due to issue with gtid_current_pos with galera
+      // cluster, gtid_binlog_pos works as well with normal mariadb server
+      // https://jira.mariadb.org/browse/MDEV-10279
+      m_store_result_row_free(mr);
+      mr = m_store_result_row(conn, "SELECT @@gtid_binlog_pos", NULL, NULL, "Failed to get @@gtid_binlog_pos", NULL);
+      if (mr->row){
+        *mastergtid = g_strdup(remove_new_line(mr->row[0]));
+      }
+    }
+  }
+  m_store_result_row_free(mr);
+}
+
 // Here is where the backup process start
 
 void start_dump(struct configuration *conf, GOptionContext *context) {
@@ -1349,6 +1374,9 @@ void start_dump(struct configuration *conf, GOptionContext *context) {
   trace("End Job Creation");
   // End Job Creation
 
+  // Get initial binlog position
+  get_binlog_position(conn, &initial_source_log, &initial_source_pos, &initial_source_gtid);
+
   // Starting the chunk builder
   start_chunk_builder(conf);
 
@@ -1357,6 +1385,8 @@ void start_dump(struct configuration *conf, GOptionContext *context) {
   g_async_queue_pop(conf->source_and_replica_status_queue);
   g_async_queue_unref(conf->source_and_replica_status_queue);
 
+
+  // Get initial binlog position again to determine backup consistency
   gchar *source_log = NULL;
   gchar *source_pos = NULL;
   gchar *source_gtid = NULL;

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -530,37 +530,11 @@ void check_connection_status(struct thread_data *td){
   }
 }
 
-
-void get_binlog_position(MYSQL *conn, char **masterlog, char **masterpos, char **mastergtid){
-  trace("Getting binary log position");
-  struct M_ROW *mr = m_store_result_row(conn, show_binary_log_status, m_warning, m_message, "Couldn't get master position", NULL);
-  if ( mr->row ) {
-    *masterlog = g_strdup(mr->row[0]);
-    *masterpos = g_strdup(mr->row[1]);
-    // Oracle/Percona GTID
-    if (mysql_num_fields(mr->res) == 5) {
-      *mastergtid = g_strdup(remove_new_line(mr->row[4]));
-    } else {
-      // Let's try with MariaDB 10.x
-      // Use gtid_binlog_pos due to issue with gtid_current_pos with galera
-      // cluster, gtid_binlog_pos works as well with normal mariadb server
-      // https://jira.mariadb.org/browse/MDEV-10279      
-      m_store_result_row_free(mr);
-      mr = m_store_result_row(conn, "SELECT @@gtid_binlog_pos", NULL, NULL, "Failed to get @@gtid_binlog_pos", NULL);
-      if (mr->row){
-        *mastergtid = g_strdup(remove_new_line(mr->row[0]));
-      }
-    }
-  }
-  m_store_result_row_free(mr);
-}
-
-
 /* Write some stuff we know about snapshot, before it changes */
 static
-void write_source_info(MYSQL *conn, FILE *file) {
+void write_source_info(FILE *file) {
 
-  get_binlog_position(conn, &initial_source_log, &initial_source_pos, &initial_source_gtid);
+//  get_binlog_position(conn, &initial_source_log, &initial_source_pos, &initial_source_gtid);
 
   if (initial_source_log) {
     fprintf(file, "\n[source]\n# Channel_Name = '' # It can be use to setup replication FOR CHANNEL\n");
@@ -715,7 +689,7 @@ gboolean process_job_builder_job(struct thread_data *td, struct job *job){
       break;
     case JOB_WRITE_SOURCE_AND_REPLICA_STATUS:
 //      if (source_data.enabled)
-      write_source_info(td->thrconn, job->job_data);
+      write_source_info(job->job_data);
       // Write replica information
       if ((get_product() != SERVER_TYPE_TIDB) && replica_data.enabled)
           write_replica_info(td->thrconn, job->job_data);

--- a/src/mydumper/mydumper_working_thread.h
+++ b/src/mydumper/mydumper_working_thread.h
@@ -66,4 +66,3 @@ void build_lock_tables_statement(struct configuration *conf);
 void check_pause_resume( struct thread_data *td );
 void update_estimated_remaining_chunks_on_dbt(struct db_table *dbt);
 void free_db_table(struct db_table * dbt);
-void get_binlog_position(MYSQL *conn, char **masterlog, char **masterpos, char **mastergtid);


### PR DESCRIPTION
This is major fix over the SAFE_NO_LOCK mode of the parameter --sync-thread-lock-mode. 
The problem was that the get_binlog function was executed inside a thread that might or might not be at the same point in time of the other threads. 
The logic was move to the main connection which now will execute both, the initial point in time and after all the threads are in ready. 
Again, SAFE_NO_LOCK considers that if there is no change in the binlog between the time all the threads send the START TRANSACTION WITH CONSISTENT SNAPSHOT, the backup will be consistent.