### PR TITLE
cacelled --> cancelled

### DIFF
--- a/src/mydumper/mydumper_integer_chunks.c
+++ b/src/mydumper/mydumper_integer_chunks.c
@@ -897,7 +897,7 @@ void process_integer_chunk(struct table_job *tj, struct chunk_step_item *csi){
                         NULL);
       g_free(thread_id);
     } else {
-      g_message("Thread %d: Job has been cacelled",td->thread_id);
+      g_message("Thread %d: Job has been cancelled",td->thread_id);
     }
     return;
   }
@@ -927,7 +927,7 @@ void process_integer_chunk(struct table_job *tj, struct chunk_step_item *csi){
                           NULL);
         g_free(thread_id);
       } else {
-        g_message("Thread %d: Job has been cacelled",td->thread_id);
+        g_message("Thread %d: Job has been cancelled",td->thread_id);
       }
       return;
     }

--- a/src/mydumper/mydumper_string_chunks.c
+++ b/src/mydumper/mydumper_string_chunks.c
@@ -1071,7 +1071,7 @@ void process_string_chunk(struct table_job *tj, struct chunk_step_item *csi){
                         NULL);
       g_free(thread_id);
     } else {
-      g_message("Thread %d: Job has been cacelled",td->thread_id);
+      g_message("Thread %d: Job has been cancelled",td->thread_id);
     }
     return;
   }

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -803,7 +803,7 @@ void process_queue(GAsyncQueue * queue, struct thread_data *td, gboolean do_buil
                                "dump_thread", "shutdown", "cancelled",
                                td->thread_id, NULL, NULL);
       } else {
-        g_message("Thread %d: Process has been cacelled",td->thread_id);
+        g_message("Thread %d: Process has been cancelled",td->thread_id);
       }
       return;
     }


### PR DESCRIPTION
Hey !

While working on a looping mydumper backup, I've killed the process while tailing the log and seen:

```
2026-06-03 12:57:15 [INFO] - Thread 3: Job has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 6: Job has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 2: Job has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 5: Job has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 2: Process has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 3: Process has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 6: Process has been cacelled
2026-06-03 12:57:15 [INFO] - Thread 5: Process has been cacelled
2026-06-03 12:59:31 [INFO] - Thread 4: Job has been cacelled
2026-06-03 12:59:31 [INFO] - Thread 4: Process has been cacelled
2026-06-03 12:59:33 [INFO] - Thread 1: Job has been cacelled
2026-06-03 12:59:33 [INFO] - Thread 1: Process has been cacelled
```

This PR is replacing `cacelled` by `cancelled`, which is the correct British English spelling:
https://www.merriam-webster.com/grammar/canceled-or-cancelled

Kind regards,
Julien 