### PR TITLE
Fix segfault when EXPLAIN output has no rows column (explain_format=TREE/JSON)

### DIFF
--- a/src/mydumper/mydumper_chunks.c
+++ b/src/mydumper/mydumper_chunks.c
@@ -256,16 +256,40 @@ cleanup:
 }
 
 
+// Only the MySQL family supports the explain_format system variable (added in
+// MySQL 8.3), which can change the output of a plain EXPLAIN to TREE or JSON,
+// and accepts forcing the format back with EXPLAIN FORMAT=TRADITIONAL
+static
+gboolean explain_format_can_be_forced(){
+  switch (get_product()){
+    case SERVER_TYPE_MYSQL:
+    case SERVER_TYPE_PERCONA:
+    case SERVER_TYPE_RDS:
+    case SERVER_TYPE_GOOGLE:
+    case SERVER_TYPE_UNKNOWN:
+      return TRUE;
+    default:
+      return FALSE;
+  }
+}
+
 guint64 get_rows_from_explain(MYSQL * conn, struct db_table *dbt, GString *where, gchar *field){
-  gchar *query = g_strdup_printf(
-                        "EXPLAIN SELECT %s %s%s%s FROM %s%s%s.%s%s%s%s%s",
+  const gchar *explain_statement = "EXPLAIN";
+  gchar *query = NULL;
+  struct M_ROW *mr = NULL;
+  guint row_col = 0;
+
+execute_explain:
+  query = g_strdup_printf(
+                        "%s SELECT %s %s%s%s FROM %s%s%s.%s%s%s%s%s",
+                        explain_statement,
                         is_mysql_like() ? "/*!40001 SQL_NO_CACHE */": "",
                         field?identifier_quote_character_str:"", field?field:"*", field?identifier_quote_character_str:"",
                         identifier_quote_character_str, dbt->database->source_database, identifier_quote_character_str, identifier_quote_character_str, dbt->table, identifier_quote_character_str,
                         where?" WHERE ":"",where?where->str:"");
   /* Get minimum/maximum */
   trace("EXPLAIN: %s", query);
-  struct M_ROW *mr = m_store_result_row(conn, query, 
+  mr = m_store_result_row(conn, query,
                         m_critical, m_warning, "Failed to execute EXPLAIN: %s", query);
 
   g_free(query);
@@ -274,8 +298,17 @@ guint64 get_rows_from_explain(MYSQL * conn, struct db_table *dbt, GString *where
     return 0;
   }
 
-  guint row_col=-1;
-  determine_explain_columns(mr->res, &row_col);
+  if (!determine_explain_columns(mr->res, &row_col)){
+    m_store_result_row_free(mr);
+    // The EXPLAIN output has no rows column when explain_format is set to
+    // TREE or JSON: retry once forcing the TRADITIONAL format
+    if (!g_strcmp0(explain_statement, "EXPLAIN") && explain_format_can_be_forced()){
+      explain_statement = "EXPLAIN FORMAT=TRADITIONAL";
+      goto execute_explain;
+    }
+    g_warning("Unable to determine the estimated amount of rows of `%s`.`%s`: EXPLAIN output has no rows column", dbt->database->source_database, dbt->table);
+    return 0;
+  }
 
   if ( mr->row[row_col]==NULL){
     m_store_result_row_free(mr);

--- a/src/mydumper/mydumper_common.c
+++ b/src/mydumper/mydumper_common.c
@@ -377,15 +377,18 @@ void determine_show_table_status_columns(MYSQL_RES *result, guint *ecol, guint *
   g_assert(*collcol > 0);
 }
 
-void determine_explain_columns(MYSQL_RES *result, guint *rowscol){
+gboolean determine_explain_columns(MYSQL_RES *result, guint *rowscol){
   MYSQL_FIELD *fields = mysql_fetch_fields(result);
   guint i = 0;
+  gboolean rows_column_found = FALSE;
   for (i = 0; i < mysql_num_fields(result); i++) {
-    if (!strcasecmp(fields[i].name, "rows"))
+    if (!strcasecmp(fields[i].name, "rows") ||
+        !strcasecmp(fields[i].name, "estRows")){ // estRows is used by TiDB
       *rowscol = i;
-    if (!strcasecmp(fields[i].name, "estRows")) // TiDB
-      *rowscol = i;
+      rows_column_found = TRUE;
+    }
   }
+  return rows_column_found;
 }
 
 void determine_charset_and_coll_columns_from_show(MYSQL_RES *result, guint *charcol, guint *collcol){

--- a/src/mydumper/mydumper_common.h
+++ b/src/mydumper/mydumper_common.h
@@ -43,7 +43,7 @@ gchar * build_filename(char *database, char *table, guint64 part, guint sub_part
 gchar * build_sql_filename(char *database, char *table, guint64 part, guint sub_part);
 gchar * build_rows_filename(char *database, char *table, guint64 part, guint sub_part);
 void determine_show_table_status_columns(MYSQL_RES *result, guint *ecol, guint *ccol, guint *collcol, guint *rowscol);
-void determine_explain_columns(MYSQL_RES *result, guint *rowscol);
+gboolean determine_explain_columns(MYSQL_RES *result, guint *rowscol);
 void determine_charset_and_coll_columns_from_show(MYSQL_RES *result, guint *charcol, guint *collcol);
 unsigned long m_real_escape_string(MYSQL *conn, char *to, const gchar *from, unsigned long length);
 void m_replace_char_with_char(gchar needle, gchar replace, gchar *str, unsigned long length);


### PR DESCRIPTION
## Problem

`mydumper` crashes with SIGSEGV at the very start of the data export phase when the server returns `EXPLAIN` output without a `rows` column. This happens on MySQL 8.3+ when the `explain_format` system variable is set to `TREE` or `JSON`: a plain `EXPLAIN SELECT ...` then returns a single column named `EXPLAIN`, with no `rows` column.

The culprit is in `get_rows_from_explain()`:

```c
guint row_col=-1;                             // guint, so 4294967295
determine_explain_columns(mr->res, &row_col); // sets row_col only if a rows/estRows column exists
if ( mr->row[row_col]==NULL){                 // wild out-of-bounds read -> SIGSEGV
```

When `determine_explain_columns()` does not find a `rows`/`estRows` column, `row_col` keeps its initial value `(guint)-1` and `mr->row[4294967295]` reads arbitrary memory. This matches all the symptoms reported in #2307: deterministic crash right after "Starting exporting data for Transactional tables" (before any "has ~N rows" message is printed), identical faulting instruction offset on every run, and no effect from `--compress`, thread count or `--server-version` (the crash depends on the shape of the server's EXPLAIN output, not on the parsed version).

## Reproduction

Against MySQL 8.4 started with `--explain-format=TREE`, any dump crashes at the start of the data export phase, even for a single 2-row table:

```
mydumper --database db_name --tables-list db_name.some_table --outputdir /tmp/out
```

## Fix

- `determine_explain_columns()` now returns whether the `rows`/`estRows` column was found.
- When the column is missing, `get_rows_from_explain()` retries once forcing `EXPLAIN FORMAT=TRADITIONAL` (only for MySQL-family servers; MariaDB and TiDB always include the column, so they never reach the retry).
- If the column is still missing, it logs a warning and returns 0 rows (falling back to a full table scan) instead of crashing.

## Verification

Tested against MySQL 8.4.10 started with `--explain-format=TREE` and a 2-row table:

- unpatched build: deterministic segfault, log identical to #2307;
- patched build: the retry kicks in, the row count is estimated correctly ("has ~2 rows") and the dump completes with the correct data;
- with `explain_format=TRADITIONAL` the behavior is unchanged (the retry never triggers).

I have also been running this patch live against the server where the issue was originally reported and the dump now completes successfully.

Fixes #2307

I'm not sure this is fully ready to merge as-is, but hopefully it can be a good starting point for the fix.

This PR was opened with the help of Claude Code.