### PR TITLE
myloader: skip LOAD DATA .dat wait in directory mode to avoid restore deadlock

### DIFF
--- a/src/myloader/myloader_restore.c
+++ b/src/myloader/myloader_restore.c
@@ -884,8 +884,13 @@ int restore_data_from_mydumper_file(struct thread_data *td, const char *filename
           gchar *to = strchr(from, '\'');
           if (to == NULL) goto STMT_IGNORED;
           load_data_filename=g_strndup(from, to-from);
-          /* Wait for .dat file to be available (in streaming mode) */
-          load_data_mutex_locate(load_data_filename);
+          /* Wait for .dat file to be available (in streaming mode).
+             In directory mode the .dat file is already on disk, and waiting here can
+             deadlock: this thread holds a decompressor slot and a connection while the
+             file-type workers (the only threads that can signal this condition) may be
+             blocked waiting for those same decompressor slots. */
+          if (stream)
+            load_data_mutex_locate(load_data_filename);
           gchar **command=NULL;
 //          int load_data_child_pid = 0;  // Issue #2075: Track subprocess for FIFO unlink
           gboolean is_fifo = get_command_and_basename(load_data_filename, &command, &load_data_fifo_filename);


### PR DESCRIPTION
# Problem

Fixes #2297.

On large **LOAD_DATA + compressed** dumps restored from a directory (tens of thousands of files), myloader stops right after logging `Intermediate thread: SHUTDOWN` and stays alive forever with ~0 CPU. All MySQL connections show `Sleep`.

It is a deadlock between three thread groups over two bounded pools:

1. Each **loader thread** restoring a chunk holds a **decompressor slot** (`myl_open()` on the `.sql.zst`, pool size = `--threads`) and a **connection** (pool size = `--threads`), then blocks in `load_data_mutex_locate("<table>.dat.zst")` waiting for the `.dat` file to be marked "ready".
2. The only code that marks it ready is a **file-type worker** popping the matching `LOAD_DATA` queue item. But all file-type workers are blocked in `myl_open()` waiting for the decompressor slots **held by the loaders**.
3. All **schema threads** block on the empty connection pool (connections also held by the loaders). That is why the log shows `restoring table schema` lines with no matching `Table ... created`.

Nobody can move. Confirmed with `gdb thread apply all bt` on a reproduced hang (v1.0.3-1, same code on master):

* 4 loader threads in `load_data_mutex_locate` (`myloader_restore.c:888`)
* 4 file-type workers in `myl_open` → `g_cond_wait(decompress_cond)` (`myloader_process.c:102`)
* all schema threads in `wait_for_available_restore_thread` → `g_async_queue_pop(connection_pool)` (`myloader_restore.c:425`)
* live globals: `active_decompressors = 1` (all slots taken), `all_jobs_are_enqueued = 0`

It needs a big dump because the hang requires data chunks to be dispatched while schema files are still being parsed. Small dumps (a few hundred files) finish parsing first and never hit the window. Reproduced reliably with ~40k files / 1100 tables (hangs on the 1st–3rd attempt); matches the reporter's ~12k-file threshold and our production hangs at ~39.8k files.

# Solution

The wait in `restore_data_from_mydumper_file()` exists for **stream mode**, where the `.sql` file can arrive before its `.dat` file. In **directory mode** the `.dat` file is already on disk before the `LOAD DATA` statement is read, so the wait is not needed — only guard it with `if (stream)`.

# Behavior change

* **Directory mode (`--directory`)**: loader threads no longer wait for the `LOAD_DATA` queue item before running `LOAD DATA`. The deadlock is gone. No functional change otherwise — the `.dat` file is always present in a complete dump directory.
* **Stream mode (`--stream`)**: unchanged, the wait still happens.

Validated on the reproduction setup: unpatched binary hung 3/3 campaigns; patched binary passed 7/7 attempts and completed a full 40,526-file restore with 0 errors and correct row counts and indexes.

# Before (deadlock)

```mermaid
sequenceDiagram
    participant L as Loader thread (x4)
    participant P as Slot/conn pools (size = --threads)
    participant F as File-type worker (x4)
    participant S as Schema thread

    L->>P: take decompressor slot (open .sql.zst)
    L->>P: take connection
    L->>L: wait: ".dat ready" (load_data_mutex_locate)
    Note over L: parked, holding slot + connection
    F->>P: need slot to parse next -schema.sql.zst
    Note over F: parked, no slots left
    Note over F: never reaches the LOAD_DATA item<br/>that would wake the loaders
    S->>P: need connection for DROP/CREATE TABLE
    Note over S: parked, no connections left
    Note over L,S: deadlock - process idle forever
```

# After (fix)

```mermaid
sequenceDiagram
    participant L as Loader thread (x4)
    participant P as Slot/conn pools (size = --threads)
    participant F as File-type worker (x4)
    participant S as Schema thread

    L->>P: take decompressor slot (open .sql.zst)
    L->>P: take connection
    Note over L: directory mode: .dat already on disk,<br/>no wait - run LOAD DATA
    L->>P: release slot + connection
    F->>P: take slot, parse -schema.sql.zst
    F->>P: release slot
    S->>P: take connection, DROP/CREATE TABLE
    S->>P: release connection
    Note over L,S: restore completes
```

Full analysis (backtraces, reproduction scripts, `--debug` traces) is written up in #2297.

# How this was tested

Environment: Docker (linux/arm64) — myloader built from the unmodified v1.0.3-1 tarball on Alpine 3.21 with `-g` (the touched code is identical on master), `mysql:8.0` as target, [toxiproxy](https://github.com/Shopify/toxiproxy) adding 8 ms latency between myloader and MySQL (simulates a remote server and widens the schema-creation phase), container limited to 2 CPUs.

## Reproduction steps

1. Create source data: 1 schema, 1100 InnoDB tables (id PK + 2 secondary indexes), 2000 rows each (~130 KB per table, so each `.dat` is bigger than a pipe buffer).
2. Dump it:

   ```sh
   mydumper --format load_data --include-header --compress ZSTD --use-single-column \
            --chunk-filesize 50 --order-by-primary --threads 8 -B testdb -o /dump
   ```

3. Multiply each table's chunk pair 16 more times to reach **40,526 files** (copy `X.00000.dat.zst` to `X.00001..00016.dat.zst`; for each copied `.sql.zst`, decompress, `sed` the `.dat` filename inside the `LOAD DATA` statement, recompress). File count is the trigger; content does not matter.
4. Copy the dump into a tmpfs directory **in shuffled file order** (tmpfs returns readdir in creation order). This simulates the effectively random readdir order of a real large dump directory — the ingredient that lets data chunks dispatch while schema files are still being parsed.
5. Restore:

   ```sh
   myloader -h <host-via-toxiproxy> --local-infile --drop-table --checksum skip \
            --max-threads-per-table 1 --max-threads-for-index-creation 4 \
            --max-threads-for-schema-creation 4 --optimize-keys after_import_per_table \
            --skip-definer --show-warnings --threads 4 --verbose 3 \
            --source-db testdb --database testdb_restored --directory /dump-shuffled
   ```

6. A watcher script polls the log; if it is idle for 60 s while the process is alive, it dumps `gdb -p <pid> -batch -ex "thread apply all bt"`.

Each attempt takes 2–3 minutes; the hang fires within the first 1–3 attempts.

## Proof — unpatched binary (hangs)

Three campaigns, three hangs (attempts 1, 3, 1). Watcher output of the last one:

```text
=== HANG_CAPTURED attempt=1 main=1534241 log_idle=63s ===
```

Log tail at the hang — matches the production signature exactly: 4 (= `--threads`) `restoring data chunk` lines, 26 `restoring table schema` vs only 14 `table schema created` (12 = number of schema threads stuck mid-job), and `Intermediate thread: SHUTDOWN` as the final line ever:

```text
08:17:20.105052  restoring data chunk            <- 4th and last one
08:17:20.105308  restoring table schema
...(9 more "restoring table schema")...
08:17:21.861035  Intermediate thread: SHUTDOWN   <- last log line, forever
```

`gdb thread apply all bt` on the hung process — all 4 loader threads:

```text
#3 load_data_mutex_locate (filename="...t944.00002.dat.zst") at myloader_restore.c:636
#4 restore_data_from_mydumper_file (filename="...t944.00002.sql.zst") at myloader_restore.c:888
#5 process_restore_job at myloader_restore_job.c:489
```

all 4 file-type workers:

```text
#3 myl_open (filename=".../t378-schema.sql.zst", "r") at myloader_process.c:102   <- g_cond_wait(decompress_cond)
#4 parse_create_table_from_file at myloader_process.c:222
#5 process_table_filename at myloader_process.c:556
#6 process_file_type_worker at myloader_process_file_type.c:154
```

all 12 schema threads:

```text
#5 wait_for_available_restore_thread at myloader_restore.c:425   <- g_async_queue_pop(connection_pool)
#6 restore_data_in_gstring_extended at myloader_restore.c:1032
#8 process_restore_job at myloader_restore_job.c:360/379         <- DROP/CREATE TABLE
#9 process_schema at myloader_worker_schema.c:173
```

Live globals read from the hung process and server state:

```text
(gdb) p active_decompressors   -> 1   (all 4 slots checked out)
(gdb) p threads_waiting        -> 0
(gdb) p all_jobs_are_enqueued  -> 0
mysql> SELECT command,COUNT(*) FROM information_schema.processlist WHERE user='dump' GROUP BY 1;
Sleep | 5        (4 pool connections held by parked loaders + 1 main; nothing running)
```

The same capture was repeated on a second hang with an identical signature (4x `load_data_mutex_locate`, 4x `myloader_process.c:102`, 12x `myloader_restore.c:425`).

## Proof — patched binary (same dump, same flags)

7/7 attempts pass the point where the unpatched binary deadlocks (`NO_HANG after 6 attempts` + 1 earlier attempt), and one full run to completion:

```text
"message":"restore completed", "duration_ms":"497386", "tables":"1100",
"files":"40526", "bytes":"106182002", "errors":"0", "warnings":"0",
"retries":"0", "skipped":"0", "exit_code":"0"
```

Data verified after the full restore:

```text
tables=1100
t5_rows=2000  t5_sum_other=2001000   (= sum 1..2000, correct)
t1100_rows=2000
t42_indexes=3                        (PK + 2 secondary, rebuilt by --optimize-keys)
```


# One-command reproduction kit

Four files, nothing else to install (only Docker). Put them in one directory and run:

```sh
docker compose run --rm repro
```

It builds myloader v1.0.3-1 from the release tarball (the touched code is identical on master), starts MySQL 8.0 and toxiproxy (8 ms latency, simulating a remote server), generates 1100 tables, creates a ~38k-file LOAD_DATA+ZSTD dump, and restores it in a loop. When the hang fires it prints the log tail, the deadlock accounting, and full `gdb` backtraces of every thread, then exits 0. Takes about 15 minutes end to end including the image build; the hang usually fires on attempt 1-3 (2-3 min per attempt). Tunables: `TABLES`, `ROWS`, `EXTRA_PARTS`, `ATTEMPTS`, `IDLE_SECS`.

Verified output of a fresh run (hang on attempt 1):

```text
==== HANG REPRODUCED on attempt 1 (pid 211288, log idle 63s) ====
==== log tail:
  2026-08-04 10:54:02.411792  table schema created
  2026-08-04 10:54:02.411829  restoring table schema
  2026-08-04 10:54:02.411838  Dropping table or view (if exists) testdb_restored.t384
  2026-08-04 10:54:02.464350  Thread 6: Creating table testdb_restored.t1098 from content in /dev/shm/dump/testdb.t1098-schema.sql.zst. On db: testdb
  2026-08-04 10:54:02.526101  table schema created
  2026-08-04 10:54:02.526150  restoring table schema
  2026-08-04 10:54:02.526230  Dropping table or view (if exists) testdb_restored.t592
  2026-08-04 10:54:03.824633  Intermediate thread: SHUTDOWN
==== counters:
  restoring data chunk : 4   (= --threads, the parked loaders)
  restoring table schema: 25
  table schema created  : 13
==== deadlock accounting (from gdb thread apply all bt):
  loader threads parked in load_data_mutex_locate : 4
  threads waiting for a decompressor slot         : 4
  threads waiting for a connection                : 12
```

<details><summary><b>compose.yaml</b></summary>

```yaml
services:
  mysql:
    image: mysql:8.0
    environment:
      MYSQL_ROOT_PASSWORD: root
    command: --local-infile=1 --max-connections=200 --skip-log-bin
    volumes:
      - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
    tmpfs:
      - /var/lib/mysql:rw,size=6g
    healthcheck:
      test: ["CMD", "mysqladmin", "ping", "-uroot", "-proot"]
      interval: 2s
      retries: 60

  toxiproxy:
    image: ghcr.io/shopify/toxiproxy:latest

  repro:
    build: .
    depends_on:
      mysql:
        condition: service_healthy
      toxiproxy:
        condition: service_started
    # a k8s-pod-like CPU budget keeps the timing realistic
    cpus: 2
    shm_size: 3gb
    cap_add:
      - SYS_PTRACE   # for gdb backtraces of the hung process
    command: bash /repro.sh
```
</details>

<details><summary><b>Dockerfile</b></summary>

```dockerfile
FROM alpine:3.21
RUN apk add --no-cache cmake build-base glib-dev mariadb-dev zlib-dev pcre-dev openssl-dev zstd-dev \
    gdb zstd mysql-client bash coreutils procps curl
ARG MYDUMPER_VERSION=1.0.3-1
ADD https://github.com/mydumper/mydumper/archive/refs/tags/v${MYDUMPER_VERSION}.tar.gz /tmp/mydumper.tar.gz
RUN mkdir -p /opt/mydumper-src && tar -xzf /tmp/mydumper.tar.gz --strip-components=1 -C /opt/mydumper-src
WORKDIR /opt/mydumper-src
RUN cmake -DWITH_ZSTD=ON -DCMAKE_C_FLAGS="-g -O2 -fno-omit-frame-pointer" . && \
    make -j"$(nproc)" && \
    cp mydumper myloader /usr/bin/
COPY repro.sh /repro.sh
CMD ["bash", "/repro.sh"]
```
</details>

<details><summary><b>init.sql</b></summary>

```sql
-- mydumper/myloader are built against the MariaDB connector; use a
-- mysql_native_password user so it can authenticate without TLS.
CREATE USER IF NOT EXISTS 'dump'@'%' IDENTIFIED WITH mysql_native_password BY 'dump';
GRANT ALL PRIVILEGES ON *.* TO 'dump'@'%';
FLUSH PRIVILEGES;
```
</details>

<details><summary><b>repro.sh</b></summary>

```bash
#!/bin/bash
# Reproduces the myloader directory-mode LOAD_DATA deadlock (mydumper/mydumper#2297).
#
# Steps: generate tables -> mydumper (load_data + ZSTD) -> multiply chunk files to ~40k
# -> copy to tmpfs in shuffled order (random readdir order) -> restore in a loop until
# the hang fires -> dump gdb backtraces of every thread.
#
# Usage: docker compose run --rm repro          (hang usually fires on attempt 1-3)
set -e
TABLES=${TABLES:-1100}
ROWS=${ROWS:-2000}
EXTRA_PARTS=${EXTRA_PARTS:-16}   # per-table chunk copies 00001..000NN in addition to 00000
ATTEMPTS=${ATTEMPTS:-10}
IDLE_SECS=${IDLE_SECS:-60}       # "hung" = process alive but log idle this long
MYSQL="mysql --skip-ssl -h mysql -uroot -proot"

echo "== waiting for mysql"
until mysqladmin --skip-ssl -h mysql -uroot -proot ping >/dev/null 2>&1; do sleep 1; done

echo "== configuring toxiproxy: 8ms latency between myloader and mysql"
curl -s -X POST toxiproxy:8474/proxies \
  -d '{"name":"mysql","listen":"0.0.0.0:3307","upstream":"mysql:3306"}' >/dev/null || true
curl -s -X POST toxiproxy:8474/proxies/mysql/toxics \
  -d '{"type":"latency","attributes":{"latency":8,"jitter":3}}' >/dev/null || true

echo "== generating $TABLES tables x $ROWS rows"
{
  echo "SET SESSION cte_max_recursion_depth=100000;"
  echo "CREATE DATABASE IF NOT EXISTS testdb; USE testdb;"
  for i in $(seq 1 "$TABLES"); do
    echo "CREATE TABLE IF NOT EXISTS t$i (id INT NOT NULL AUTO_INCREMENT, val VARCHAR(64), other INT,
          PRIMARY KEY(id), KEY idx_other (other), KEY idx_val (val)) ENGINE=InnoDB;"
    echo "INSERT INTO t$i (val, other) SELECT CONCAT(REPEAT('x',55), n), n
          FROM (WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n<$ROWS) SELECT n FROM seq) s;"
  done
} | $MYSQL

echo "== dumping with mydumper (load_data + ZSTD)"
rm -rf /dump && mkdir /dump
mydumper -h mysql -u dump -p dump -B testdb \
  --format load_data --include-header --compress ZSTD --use-single-column \
  --chunk-filesize 50 --order-by-primary --threads 8 -o /dump

echo "== multiplying chunk pairs to raise the file count (the trigger is file count, not data)"
cd /dump
for sql in *.00000.sql.zst; do
  base=${sql%.00000.sql.zst}
  for p in $(seq -f '%05g' 1 "$EXTRA_PARTS"); do
    zstd -q -d -c "$sql" | sed "s/\.00000\.dat/.${p}.dat/g" | zstd -f -q -o "${base}.${p}.sql.zst"
    cp -f "${base}.00000.dat.zst" "${base}.${p}.dat.zst"
  done
done
echo "== dump has $(ls /dump | wc -l) files"

echo "== copying dump to tmpfs in SHUFFLED order (tmpfs readdir = creation order;"
echo "   this simulates the effectively random readdir order of a real large dump dir)"
rm -rf /dev/shm/dump && mkdir /dev/shm/dump
cp /dump/metadata /dev/shm/dump/
ls /dump | grep -v '^metadata$' | shuf | while read -r f; do cp "/dump/$f" "/dev/shm/dump/$f"; done

main_pid() {  # the multithreaded myloader (fork children share argv[0])
  for p in $(pgrep -x myloader); do
    [ "$(ls /proc/"$p"/task 2>/dev/null | wc -l)" -gt 1 ] && { echo "$p"; return; }
  done
}

for a in $(seq 1 "$ATTEMPTS"); do
  echo "== attempt $a/$ATTEMPTS $(date -u +%FT%TZ)"
  pkill -9 -x myloader 2>/dev/null || true
  pkill -9 -f '^myloader ' 2>/dev/null || true
  pkill -9 -f 'zstd -c -d' 2>/dev/null || true
  sleep 1
  # zstd children inherit myloader's MySQL sockets and keep dead sessions (and their
  # metadata locks) alive; kill leftovers so DROP DATABASE below cannot block
  $MYSQL -sN -e "SELECT id FROM information_schema.processlist WHERE user='dump'" 2>/dev/null |
    while read -r id; do $MYSQL -e "KILL $id" 2>/dev/null || true; done
  $MYSQL -e "DROP DATABASE IF EXISTS testdb_restored; CREATE DATABASE testdb_restored;"

  LOG=/tmp/restore-$a.log
  rm -f "$LOG"; touch "$LOG"
  myloader -h toxiproxy -P 3307 -u dump -p dump --local-infile \
    --drop-table --checksum skip --machine-log-json \
    --max-threads-per-table 1 --max-threads-for-index-creation 4 --max-threads-for-schema-creation 4 \
    --optimize-keys after_import_per_table --skip-definer --show-warnings \
    --threads 4 --verbose 3 \
    --source-db testdb --database testdb_restored \
    --directory /dev/shm/dump > "$LOG" 2>&1 &
  MYPID=$!

  while :; do
    if ! kill -0 "$MYPID" 2>/dev/null; then
      wait "$MYPID" || true
      echo "== attempt $a: myloader exited normally (chunks restored: $(grep -c 'restoring data chunk' "$LOG"))"
      break
    fi
    # once well past the schema/data overlap window this attempt won't wedge; retry
    if grep -q '"progress_value":"5000"' "$LOG" 2>/dev/null; then
      echo "== attempt $a: passed the danger window without hanging, retrying"
      kill -9 "$MYPID" 2>/dev/null || true; wait "$MYPID" 2>/dev/null || true
      break
    fi
    NOW=$(date +%s); MTIME=$(stat -c %Y "$LOG")
    if [ $((NOW - MTIME)) -ge "$IDLE_SECS" ]; then
      MAIN=$(main_pid || true)
      echo ""
      echo "==== HANG REPRODUCED on attempt $a (pid $MAIN, log idle $((NOW - MTIME))s) ===="
      echo "==== log tail:"
      grep -oE '"ts":"[^"]+"[^}]*"message":"[^"]+"' "$LOG" | tail -8 \
        | sed -E 's/.*"ts":"([^"]+)".*"message":"([^"]+)".*/  \1  \2/'
      echo "==== counters:"
      echo "  restoring data chunk : $(grep -c 'restoring data chunk' "$LOG")   (= --threads, the parked loaders)"
      echo "  restoring table schema: $(grep -c 'restoring table schema' "$LOG")"
      echo "  table schema created  : $(grep -c 'table schema created' "$LOG")"
      gdb -p "$MAIN" -batch -ex "set pagination off" -ex "thread apply all bt" > /tmp/backtraces.txt 2>&1 || true
      echo "==== deadlock accounting (from gdb thread apply all bt):"
      grep -cE 'load_data_mutex_locate'   /tmp/backtraces.txt | xargs echo "  loader threads parked in load_data_mutex_locate :"
      grep -cE 'myloader_process\.c:102'  /tmp/backtraces.txt | xargs echo "  threads waiting for a decompressor slot         :"
      grep -cE 'myloader_restore\.c:425'  /tmp/backtraces.txt | xargs echo "  threads waiting for a connection                :"
      echo "==== full backtraces:"
      cat /tmp/backtraces.txt
      exit 0
    fi
    sleep 5
  done
done
echo "== no hang after $ATTEMPTS attempts (timing-dependent; re-run, or raise EXTRA_PARTS)"
exit 1
```
</details>

To verify the fix with the same kit, build this PR branch instead of the tarball in the Dockerfile (or apply the one-line guard before `cmake`), `docker compose build`, and re-run: every attempt passes the point where the unpatched binary deadlocks, and a full restore completes with 0 errors.
