### PR TITLE
Warn when --regex excludes the database object (#2329)

### DIFF
--- a/src/mydumper/mydumper_database.c
+++ b/src/mydumper/mydumper_database.c
@@ -56,6 +56,8 @@ static struct database *new_database(MYSQL *conn, char *database_name)
   _database->source_database_escaped = escape_string(conn, _database->source_database);
   //  _database->already_dumped = already_dumped;
   //  _database->ad_mutex=g_mutex_new();
+  _database->schema_create_job_created = FALSE;
+  _database->regex_mismatch_warned = FALSE;
   _database->checksum.schema = NULL;
   _database->checksum.routine = NULL;
   _database->checksum.trigger = NULL;
@@ -136,13 +138,14 @@ void warn_if_schema_create_excluded(struct database *database)
   if (!database->regex_mismatch_warned)
   {
     database->regex_mismatch_warned = TRUE;
-    g_warning("--regex matched tables in `%s` but not the database object itself: "
-              "%s-schema-create.sql will not be dumped, and this backup will not be "
-              "restorable unless the database already exists on the target. Database "
-              "objects are matched against the bare database name, not `database.table` "
-              "- use for instance '^(%s)(\\.|$)'.",
-              database->source_database, database->database_name_in_filename,
-              database->source_database);
+    g_warning(
+        "--regex matched tables in `%s` but not the database object itself: "
+        "%s-schema-create.sql will not be dumped, and this backup will not be "
+        "restorable unless the database already exists on the target. Database "
+        "objects are matched against the bare database name, not `database.table` "
+        "- use for instance '^(%s)(\\.|$)'.",
+        database->source_database, database->database_name_in_filename,
+        database->source_database);
   }
   g_mutex_unlock(database_hash_mutex);
 }

--- a/src/mydumper/mydumper_database.c
+++ b/src/mydumper/mydumper_database.c
@@ -109,10 +109,42 @@ struct database *get_database(MYSQL *conn, char *database_name, gboolean create_
   {
     database = new_database(conn, database_name);
     if (create_job)
+    {
       create_job_to_dump_schema(database);
+      database->schema_create_job_created = TRUE;
+    }
   }
   g_mutex_unlock(database_hash_mutex);
   return database;
+}
+
+/* Called when a table of `database` has been elected to be dumped.
+
+   --regex is evaluated against `database.table` for tables but against the bare
+   database name for the database object, so a pattern such as '^mydb\.' selects
+   every table while silently excluding the database itself.  The resulting
+   backup has no <db>-schema-create.sql and cannot be restored into a server
+   where the database does not already exist; in --stream mode myloader also
+   holds every schema job until EOF.  mydumper exits 0 either way, so warn once
+   per database instead of failing silently.  See issue #2329. */
+void warn_if_schema_create_excluded(struct database *database)
+{
+  if (no_schemas || !is_regex_being_used() || database->schema_create_job_created)
+    return;
+
+  g_mutex_lock(database_hash_mutex);
+  if (!database->regex_mismatch_warned)
+  {
+    database->regex_mismatch_warned = TRUE;
+    g_warning("--regex matched tables in `%s` but not the database object itself: "
+              "%s-schema-create.sql will not be dumped, and this backup will not be "
+              "restorable unless the database already exists on the target. Database "
+              "objects are matched against the bare database name, not `database.table` "
+              "- use for instance '^(%s)(\\.|$)'.",
+              database->source_database, database->database_name_in_filename,
+              database->source_database);
+  }
+  g_mutex_unlock(database_hash_mutex);
 }
 
 // see print_dbt_on_metadata_gstring() for table write to metadata

--- a/src/mydumper/mydumper_database.h
+++ b/src/mydumper/mydumper_database.h
@@ -31,10 +31,13 @@ struct database
   gchar                         *database_name_in_filename;
   struct database_level_checksum checksum;
   gboolean                       dump_triggers;
+  gboolean                       schema_create_job_created;
+  gboolean                       regex_mismatch_warned;
 };
 
 void             initialize_database();
 struct database *get_database(MYSQL *conn, char *database_name, gboolean create_job);
+void             warn_if_schema_create_excluded(struct database *database);
 void             free_databases();
 void             write_database_on_disk(FILE *mdfile);
 // OPTIMIZATION: Unsorted version for faster finalization

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -389,6 +389,8 @@ static void get_table_info_to_process_from_list(MYSQL *conn, struct configuratio
       if (!eval_regex(database->source_database, row[0]))
         continue;
 
+      warn_if_schema_create_excluded(database);
+
       create_job_to_dump_table(is_view, is_sequence, database, g_strdup(row[tablecol]), g_strdup(row[collcol]), g_strdup(row[ecol]));
     }
     mysql_free_result(result);
@@ -1422,6 +1424,8 @@ static void dump_database_thread(MYSQL *conn, struct database *database)
       dump_summary_note_skipped();
       continue;
     }
+
+    warn_if_schema_create_excluded(database);
 
     /* Check if the table was recently updated */
     if (no_updated_tables && !is_view && !is_sequence)

--- a/src/mydumper/mydumper_working_thread.c
+++ b/src/mydumper/mydumper_working_thread.c
@@ -389,8 +389,6 @@ static void get_table_info_to_process_from_list(MYSQL *conn, struct configuratio
       if (!eval_regex(database->source_database, row[0]))
         continue;
 
-      warn_if_schema_create_excluded(database);
-
       create_job_to_dump_table(is_view, is_sequence, database, g_strdup(row[tablecol]), g_strdup(row[collcol]), g_strdup(row[ecol]));
     }
     mysql_free_result(result);

--- a/test/specific_40/check_mydumper.sh
+++ b/test/specific_40/check_mydumper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+log=/tmp/data/specific_40.log
+
+# The tables must be dumped ...
+if [ ! -f /tmp/data/specific_40.t1-schema.sql ]
+then
+  exit 1
+fi
+
+# ... while the database object is not matched by '^specific_40\.' ...
+if [ -f /tmp/data/specific_40-schema-create.sql ]
+then
+  exit 1
+fi
+
+# ... and that must be reported instead of passing silently.
+if ! grep -q 'schema-create.sql will not be dumped' "$log"
+then
+  exit 1
+fi
+
+exit 0

--- a/test/specific_40/check_mydumper.sh
+++ b/test/specific_40/check_mydumper.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-log=/tmp/data/specific_40.log
+LOG=/tmp/test_mydumper.log.tmp
 
 # The tables must be dumped ...
 if [ ! -f /tmp/data/specific_40.t1-schema.sql ]
@@ -15,7 +15,7 @@ then
 fi
 
 # ... and that must be reported instead of passing silently.
-if ! grep -q 'schema-create.sql will not be dumped' "$log"
+if ! grep -q 'specific_40-schema-create.sql will not be dumped' "$LOG"
 then
   exit 1
 fi

--- a/test/specific_40/mydumper.cnf
+++ b/test/specific_40/mydumper.cnf
@@ -1,0 +1,12 @@
+#
+# A --regex that only matches `database.table` excludes the database object
+# itself, so <db>-schema-create.sql is not dumped. mydumper must warn about it
+# instead of exiting successfully with a backup that cannot be restored.
+# See issue #2329.
+#
+
+[mydumper]
+regex=^specific_40\.
+outputdir=/tmp/data
+logfile=/tmp/data/specific_40.log
+verbose=3

--- a/test/specific_40/mydumper.cnf
+++ b/test/specific_40/mydumper.cnf
@@ -4,9 +4,11 @@
 # instead of exiting successfully with a backup that cannot be restored.
 # See issue #2329.
 #
+# No `database=` on purpose: with -B the schema-create job is created without
+# consulting --regex, so the mismatch covered here can only be reached on the
+# all-databases path.
+#
 
 [mydumper]
 regex=^specific_40\.
 outputdir=/tmp/data
-logfile=/tmp/data/specific_40.log
-verbose=3

--- a/test/specific_40/prepare_mydumper.sql
+++ b/test/specific_40/prepare_mydumper.sql
@@ -1,0 +1,7 @@
+DROP DATABASE IF EXISTS specific_40;
+CREATE DATABASE specific_40;
+
+USE specific_40;
+
+CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, val VARCHAR(32));
+INSERT INTO t1 (val) VALUES ('a'), ('b'), ('c');


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Refs #2329.</p>
<p><code>--regex</code> is evaluated against <code>database.table</code> for tables but against the <strong>bare database name</strong> for
the database object. A pattern like <code>'^mydb\.'</code> therefore selects every table in <code>mydb</code> while silently
excluding <code>mydb</code> itself, so <code>mydb-schema-create.sql</code> is never dumped — and mydumper still exits 0.</p>
<p>The resulting backup cannot be restored into a server where the database does not already exist
(<code>ERROR 1049</code>), and in <code>--stream</code> mode myloader holds every schema job until EOF, so the loader appears
to do nothing for the entire duration of the dump. Neither mydumper nor myloader says anything.</p>
<h3>What this changes</h3>
<p>Nothing functional — one warning, emitted once per database, only when all of the following hold:</p>
<ul>
<li><code>--regex</code> is in use (<code>is_regex_being_used()</code>)</li>
<li>the database object was <strong>not</strong> matched, so no <code>CREATE DATABASE</code> dump job was created</li>
<li>at least one table from that database <strong>is</strong> being dumped</li>
<li><code>--no-schemas</code> is not set</li>
</ul>
<blockquote>
<p>--regex matched tables in <code>mydb</code> but not the database object itself: mydb-schema-create.sql
will not be dumped, and this backup will not be restorable unless the database already exists
on the target. Database objects are matched against the bare database name, not
<code>database.table</code> - use for instance '^(mydb)(.|$)'.</p>
</blockquote>
<p><code>struct database</code> gains two <code>gboolean</code> flags, both initialised in <code>new_database()</code>:
<code>schema_create_job_created</code>, set in <code>get_database()</code> where the job is actually queued, and
<code>regex_mismatch_warned</code> as the one-time guard. The call site is immediately after the table-level
<code>eval_regex()</code> check in <code>dump_database_thread()</code> — the only path where the condition can arise.
<code>--tables-list</code> and <code>-B</code> both create the schema-create job without consulting <code>--regex</code>
(<code>get_database(conn, dt[0], TRUE)</code> and <code>get_database(conn, db_items[i], !no_schemas)</code> respectively),
so only the all-databases path can select tables while excluding the database object.</p>
<p>No new includes are needed — <code>no_schemas</code> comes from <code>mydumper_global.h</code> and <code>is_regex_being_used()</code>
is already used by <code>new_database()</code> in the same file.</p>
<p>The follow-up commit fixes two problems found while getting CI green. <code>new_database()</code> allocates with
<code>g_new</code> and initialises each field explicitly; the two new flags were left indeterminate, so when
<code>schema_create_job_created</code> read as non-zero the warning was silently suppressed — undefined behaviour
that would differ per build. And the test's <code>logfile=</code> pointed inside <code>outputdir</code>, which the harness
removes before each case; <code>set_verbose()</code> opens the log file before the output directory exists, so
mydumper aborted in <code>m_critical()</code> and every CI job that runs the e2e suite failed there.</p>
<h3>Test</h3>
<p><code>test/specific_40/</code> follows the existing <code>specific_31</code> layout — it greps the harness's own
<code>/tmp/test_mydumper.log.tmp</code> and sets neither <code>logfile=</code> nor <code>verbose=</code> — and asserts that with
<code>regex=^specific_40\.</code>:</p>
<ol>
<li>the table schema file is produced,</li>
<li><code>specific_40-schema-create.sql</code> is <strong>not</strong> produced,</li>
<li>the log contains the warning.</li>
</ol>
<p>Point 3 fails on <code>master</code> and passes with this change.</p>
<p>It deliberately sets no <code>database=</code>: with <code>-B</code> the schema-create job is created regardless of
<code>--regex</code>, which would both dump <code>specific_40-schema-create.sql</code> and suppress the warning.</p>
<h3>Verified no false positives</h3>
<p>Built from this branch and run against MySQL 8.4 with the same flags the harness applies
(<code>--checksum-all</code>, <code>--logfile</code>); the first row is the harness case itself:</p>

invocation | warning | -schema-create.sql
-- | -- | --
--regex '^specific_40\.', 1 table | shown once | not dumped
--regex '^specific_40\.', 3 tables | shown once (per-database guard holds) | not dumped
--regex '^specific_40(\.\|$)' | not shown | dumped
-B specific_40 (no regex) | not shown | dumped
--no-schemas --regex '^specific_40\.' | not shown | not dumped
-B specific_40 --regex '^specific_40\.' | not shown | dumped


<p>The last row is a deliberate limitation: with <code>-B</code> the schema-create job is created regardless of
<code>--regex</code>, so there is nothing to warn about.</p>
<p><code>-e 28:40 --skip-dynamic -d SSL</code> also passes, with <code>specific_40</code> running after the earlier cases have
left their databases on the server.</p>
<h3>Not included here</h3>
<p>Two further ideas from #2329, left out to keep this reviewable:</p>
<ul>
<li>the matching myloader-side warning, where schema jobs start being held in <code>schema_push()</code></li>
<li>documenting the two-subject matching rule in the <code>--regex</code> help text</li>
</ul>
<p>Happy to send either as a follow-up. I'd also welcome your view on the question in the issue — whether
myloader should fall back to <code>CREATE DATABASE IF NOT EXISTS</code> when no schema-create file arrives, rather
than holding every schema job until EOF.</p></body></html><!--EndFragment-->
</body>
</html>