### PR TITLE
Remove redundant mutex lock/unlock for fifo_table

### DIFF
--- a/src/mydumper/mydumper_file_handler.c
+++ b/src/mydumper/mydumper_file_handler.c
@@ -317,7 +317,7 @@ int m_open_pipe(gchar **filename, const char *type)
 
   g_mutex_lock(fifo_table_mutex);
   f = g_hash_table_lookup(fifo_hash, *filename);
-  g_mutex_unlock(fifo_table_mutex);
+//  g_mutex_unlock(fifo_table_mutex);
   if (f)
   {
     g_error("file already open: %s", *filename);
@@ -346,7 +346,7 @@ int m_open_pipe(gchar **filename, const char *type)
   f->child_pid = execute_file_per_thread(f->pipe, f->fdout);
 
   g_mutex_unlock(pipe_creation);
-  g_mutex_lock(fifo_table_mutex);
+//  g_mutex_lock(fifo_table_mutex);
   g_hash_table_insert(fifo_hash, f->filename, f);
   g_mutex_unlock(fifo_table_mutex);
   return f->pipe[1];


### PR DESCRIPTION
Commented out unnecessary mutex lock and unlock calls for fifo_table_mutex in mydumper_file_handler.c.