### PR TITLE
Fix silent data corruption in myloader --stream: binary carry-over truncated at first NUL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,16 @@ target_link_libraries(test_use_defer_livelock ${GLIB2_LIBRARIES})
 target_compile_definitions(test_use_defer_livelock PRIVATE USE_DEFER_FIX)
 add_test(NAME use_defer_livelock COMMAND test_use_defer_livelock)
 
+# Unit test: myloader --stream buffer carry-over (issue #1687)
+# Links the real process_stream() and drives it over hand-built streams, so it
+# reaches all four carry-over sites, including the two on the --mysqldump path
+# that cannot be reached end to end. Needs GLib, and the MySQL headers to
+# compile myloader_stream.c -- it calls nothing from the client library, so
+# there is no server and no libmysqlclient at run time.
+add_executable(test_stream_carryover test/unit/test_stream_carryover.c src/myloader/myloader_stream.c)
+target_link_libraries(test_stream_carryover ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES})
+add_test(NAME stream_carryover COMMAND test_stream_carryover)
+
 IF(RUN_CPPCHECK)
   include(CppcheckTargets)
   add_cppcheck(mydumper)

--- a/src/myloader/myloader_stream.c
+++ b/src/myloader/myloader_stream.c
@@ -17,6 +17,7 @@
 
 #include <glib/gstdio.h>
 #include <mysql.h>
+#include <string.h>
 
 #include "myloader/myloader.h"
 #include "myloader/myloader_common.h"
@@ -237,7 +238,7 @@ void *process_stream(struct configuration *stream_conf)
             // we need to copy the first 20 chars to the begining of the buffer to get relevant info
             g_message("Copying");
             diff = line_end - line_from;
-            g_strlcpy(buffer, &(buffer[line_from]), line_end - line_from + 1);
+            memmove(buffer, &(buffer[line_from]), diff);
             continue;
           }
           // Can we get relevant info?
@@ -288,7 +289,7 @@ void *process_stream(struct configuration *stream_conf)
             else
             {
               diff = buffer_len - initial_pos;
-              g_strlcpy(buffer, &(buffer[initial_pos]), diff + 1);
+              memmove(buffer, &(buffer[initial_pos]), diff);
               goto read_more;
             }
           }
@@ -446,7 +447,7 @@ void *process_stream(struct configuration *stream_conf)
             {
               // It could be a header, so we copied to the begining of the buffer
               diff = buffer_len - initial_pos;
-              g_strlcpy(buffer, &(buffer[initial_pos]), diff + 1);
+              memmove(buffer, &(buffer[initial_pos]), diff);
               // diff remains set to do not overwrite the buffer
             }
             else
@@ -466,7 +467,7 @@ void *process_stream(struct configuration *stream_conf)
               // we need to move to the begining of the buffer and reprocess
               //              g_message("Coping data %d %d: %s", initial_pos,  buffer_len, &(buffer[initial_pos])  );
               diff = buffer_len - initial_pos;
-              g_strlcpy(buffer, &(buffer[initial_pos]), diff + 1);
+              memmove(buffer, &(buffer[initial_pos]), diff);
               //              g_message("After copy data: %s | new len should be: %d", buffer , diff);
             }
             else

--- a/src/myloader/myloader_stream.c
+++ b/src/myloader/myloader_stream.c
@@ -361,7 +361,7 @@ void *process_stream(struct configuration *stream_conf)
                   // this means that the content of the file has the header tag
                   // we need to flush and continue
                   flush(buffer, line_from, line_end - 1, file, &total_size);
-                  g_message("Different file size in %s. Should be: %d | Written: %d. But continuing", filename, file_size_from_stream, total_size);
+                  trace("Different file size in %s. Should be: %d | Written: %d. But continuing", filename, file_size_from_stream, total_size);
                   continue;
                 }
                 else if (total_size > file_size_from_stream)

--- a/test/specific_41/check_mydumper.sh
+++ b/test/specific_41/check_mydumper.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Regression test for the myloader --stream carry-over (issue #1687).
+#
+# When a buffer ends in the middle of what could be a file header, myloader
+# moves the tail of the buffer back to the front and reads the rest on the
+# next fread(). That move used to be a g_strlcpy(), which stops at the first
+# NUL byte. Compressed file content is binary and full of NUL bytes, so the
+# tail was silently truncated and the bytes past the NUL were replaced with
+# whatever the previous buffer had left there. The byte count was preserved,
+# so no "Different file size" message was ever printed: the received file had
+# the right size and the wrong content.
+#
+# The trigger is a chance byte pattern at a 1 MB boundary, which is far too
+# rare to hit with a test-sized dump, so this case builds it deterministically:
+# it appends one synthetic file to the stream mydumper just produced and pads it
+# so that LF, NUL, X land on the last three bytes of the first buffer. The first
+# fread() asks for STREAM_BUFFER_SIZE - 1 bytes, so for a buffer of N those are
+# stream offsets N-4, N-3 and N-2 -- 999996/999997/999998 at the stock 1000000.
+#
+# myloader is run here rather than by the harness because the assertion is a
+# byte-for-byte comparison of the received files, which needs the files to
+# survive; the harness fails a case that leaves files behind. --stream=UNPACK
+# keeps them and skips the restore, so the case does not depend on server state.
+#
+set -u
+
+[ "${1:-0}" -eq 0 ] || exit "$1"
+
+STREAM_BUFFER_SIZE=1000000              # src/common.h
+FIRST_BUFFER_LEN=$(( STREAM_BUFFER_SIZE - 1 ))
+
+DUMP_DIR=/tmp/data
+RECV_DIR=/tmp/specific_41_recv
+STREAM=/tmp/stream.sql
+PROBE_STREAM=/tmp/specific_41_stream
+PROBE_NAME=specific_41.probe.bin
+PROBE_SIZE=1000000                      # only has to span the boundary
+EXPECTED=/tmp/specific_41_expected
+MYLOADER_ERR=/tmp/specific_41_myloader.err
+PROBE_CNF="$(dirname "$0")/probe.cnf"
+
+myloader=$(command -v myloader) || myloader=./myloader
+[ -x ./myloader ] && myloader=./myloader
+
+cleanup() { rm -rf "$RECV_DIR" "$PROBE_STREAM" "$EXPECTED" "$MYLOADER_ERR"; }
+trap cleanup EXIT
+
+fail() { echo "specific_41: $*" >&2; exit 1; }
+
+[ -s "$STREAM" ] || fail "no stream at $STREAM"
+
+# Where the probe file's content starts inside the finished stream.
+base=$(wc -c < "$STREAM" | tr -d ' ')
+header=$(printf '\n-- %s %d\n' "$PROBE_NAME" "$PROBE_SIZE" | wc -c | tr -d ' ')
+content_start=$(( base + header ))
+i0=$(( FIRST_BUFFER_LEN - 3 - content_start ))
+
+[ "$i0" -gt 0 ] && [ $(( i0 + 3 )) -lt "$PROBE_SIZE" ] ||
+  fail "dump is too large to place the probe (stream=$base, i0=$i0)"
+
+# Filler is a single repeated byte so the only LF and the only NUL in the probe
+# are the two we place on purpose.
+head -c "$i0" /dev/zero | tr '\0' 'A'                      >  "$EXPECTED"
+printf '\n\000X'                                           >> "$EXPECTED"
+head -c $(( PROBE_SIZE - i0 - 3 )) /dev/zero | tr '\0' 'A' >> "$EXPECTED"
+
+cat "$STREAM"                                     >  "$PROBE_STREAM"
+printf '\n-- %s %d\n' "$PROBE_NAME" "$PROBE_SIZE" >> "$PROBE_STREAM"
+cat "$EXPECTED"                                   >> "$PROBE_STREAM"
+
+# The whole point of the case: LF, NUL, X as the last three bytes of buffer 1.
+trigger=$(dd if="$PROBE_STREAM" bs=1 skip=$(( FIRST_BUFFER_LEN - 3 )) count=3 \
+            status=none | od -An -tx1 | tr -d ' \n')
+[ "$trigger" = "0a0058" ] ||
+  fail "probe is misaligned: bytes at $(( FIRST_BUFFER_LEN - 3 )) are $trigger, want 0a0058"
+
+rm -rf "$RECV_DIR"
+"$myloader" --user "${mysql_user:-root}" --directory "$RECV_DIR" \
+            --defaults-extra-file="$PROBE_CNF" \
+            --stream=UNPACK --checksum-all --checksum=fail \
+            --logfile /tmp/test_myloader.log.tmp < "$PROBE_STREAM" > "$MYLOADER_ERR" 2>&1
+rc=$?
+[ "$rc" -eq 0 ] || { cat "$MYLOADER_ERR" >&2; fail "myloader exited $rc"; }
+
+# 1. the synthetic file must arrive byte for byte
+cmp -s "$EXPECTED" "$RECV_DIR/$PROBE_NAME" ||
+  fail "$PROBE_NAME differs from what was sent: $(cmp -l "$EXPECTED" "$RECV_DIR/$PROBE_NAME" | wc -l) byte(s)"
+
+# 2. and so must every file of the real dump
+for f in "$DUMP_DIR"/*
+do
+  [ -f "$f" ] || fail "no files left in $DUMP_DIR to compare"
+  b=$(basename "$f")
+  [ -f "$RECV_DIR/$b" ] || fail "$b was not received"
+  cmp -s "$f" "$RECV_DIR/$b" || fail "$b differs from what was sent"
+done
+
+exit 0

--- a/test/specific_41/mydumper.cnf
+++ b/test/specific_41/mydumper.cnf
@@ -1,0 +1,14 @@
+#
+# Testing that myloader --stream carries a partial buffer over without
+# truncating it at the first NUL byte. Compressed file content is binary, so
+# the carry-over must be a plain memory move, not a string copy.
+#
+# The dump itself only has to be small: check_mydumper.sh appends a synthetic
+# file to the stream so that the byte pattern that triggers the carry-over
+# lands exactly on the STREAM_BUFFER_SIZE boundary.
+#
+
+[mydumper]
+database=specific_41
+outputdir=/tmp/data
+stream=NO_DELETE

--- a/test/specific_41/prepare_mydumper.sql
+++ b/test/specific_41/prepare_mydumper.sql
@@ -1,0 +1,11 @@
+DROP DATABASE IF EXISTS specific_41;
+CREATE DATABASE specific_41;
+
+USE specific_41;
+
+CREATE TABLE t1 (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  val VARCHAR(100)
+);
+
+INSERT INTO t1 (val) VALUES ('a'), ('b'), ('c');

--- a/test/specific_41/probe.cnf
+++ b/test/specific_41/probe.cnf
@@ -1,0 +1,10 @@
+#
+# Passed to the myloader run that check_mydumper.sh drives.
+#
+# It is deliberately NOT named myloader.cnf: that name would make the harness
+# run its own myloader stage as well. It only has to exist -- myloader emits a
+# GLib-CRITICAL from load_per_table_info_from_key_file() when no defaults file
+# was given, and the harness runs with G_DEBUG=fatal-criticals.
+#
+
+[myloader]

--- a/test/unit/test_stream_carryover.c
+++ b/test/unit/test_stream_carryover.c
@@ -1,0 +1,463 @@
+/*
+ * test_stream_carryover.c
+ *
+ * Drives the REAL process_stream() from src/myloader/myloader_stream.c over a
+ * hand-built stream and asserts that every byte that went in comes back out.
+ *
+ * Issue #1687: when a buffer boundary falls inside what could be a file
+ * header, process_stream() moves the tail of the buffer to the front and reads
+ * the rest on the next fread(). That move used to be g_strlcpy(), a string
+ * function that stops at the first NUL. The carry-over length is computed
+ * arithmetically (`diff`) while g_strlcpy()'s copy length depends on the data,
+ * so on any byte range containing a NUL the two silently disagree: the bytes
+ * after the NUL are left as whatever the previous buffer had there, and the
+ * next read still starts at `diff`. The byte count is preserved, so total_size
+ * never drifts and nothing is logged -- the file lands with the right size and
+ * the wrong content.
+ *
+ * There are four carry-over sites. Two are on the mydumper-stream path and are
+ * covered end-to-end by test/specific_41; the other two are on the mysqldump
+ * path (myloader --mysqldump), which cannot be reached end to end because
+ * mysqldump escapes 0x00 as the two characters \0 and never emits a literal
+ * NUL. This test reaches all four, because it feeds process_stream() directly.
+ *
+ * No database and no server: process_stream() only needs stdin, a directory to
+ * write into, and the handful of symbols stubbed below.
+ *
+ * Build/run:  ctest -R stream_carryover --output-on-failure
+ *
+ * REQUIRES: glib-2.0 and the MySQL/MariaDB client headers (common.h
+ * includes <mysql.h>); no client library and no server.
+ */
+
+#include <glib.h>
+#include <glib/gstdio.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* STREAM_BUFFER_SIZE, plus the prototypes of everything stubbed below -- taken
+ * from the header rather than copied, so the cases follow the constant if it is
+ * ever changed. */
+#include "common.h"
+
+/* The first fread() runs with diff == 0 and asks for stream_buffer_size - 1
+ * bytes, so the first buffer holds stream offsets [0, STREAM_BUFFER_SIZE - 2]
+ * and the last byte of the buffer is never written by fread(). */
+#define FIRST_BUFFER_LEN (STREAM_BUFFER_SIZE - 1)
+
+/* ── the globals and helpers process_stream() links against ───────────────── */
+
+gchar   *directory = NULL;
+gchar   *target_db = NULL;
+gboolean no_stream = FALSE;
+gboolean mysqldump = FALSE;
+
+void set_thread_name(const char *format, ...) { (void)format; }
+void trace(const char *format, ...) { (void)format; }
+
+void m_critical(const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  fprintf(stderr, "  m_critical: ");
+  vfprintf(stderr, fmt, ap);
+  fprintf(stderr, "\n");
+  va_end(ap);
+  exit(2);
+}
+
+GThread *m_thread_new(const gchar *title, GThreadFunc func, gpointer data, const gchar *error_text)
+{
+  (void)title;
+  (void)func;
+  (void)data;
+  (void)error_text;
+  return NULL;
+}
+
+gboolean m_filename_has_suffix(gchar const *str, gchar const *suffix)
+{
+  return g_str_has_suffix(str, suffix);
+}
+
+/* process_stream() hands finished filenames to the loader; here we drop them. */
+void process_filename_push(const gchar *filename) { (void)filename; }
+void process_filename_queue_end() {}
+
+/* mirrors src/common.c: write(2), not fwrite -- the length can be negative */
+int write_file(FILE *file, char *buff, int len)
+{
+  return (int)write(fileno(file), buff, len);
+}
+
+/* declared here rather than pulling in myloader.h, which needs <mysql.h> */
+void *process_stream(void *stream_conf);
+
+/* ── harness ──────────────────────────────────────────────────────────────── */
+
+static int failed = 0;
+
+static GString *stream_header(const char *name, gsize size)
+{
+  GString *s = g_string_new("\n-- ");
+  g_string_append(s, name);
+  g_string_append_c(s, ' ');
+  g_string_append_printf(s, "%" G_GSIZE_FORMAT, size);
+  g_string_append_c(s, '\n');
+  return s;
+}
+
+/*
+ * Deterministic filler that never contains 0x00 or 0x0a, so the only NUL and
+ * the only newline in a payload are the ones the test places on purpose.
+ */
+static GString *filler(gsize n, guint32 seed)
+{
+  GString *s = g_string_sized_new(n);
+  guint32  x = seed;
+  for (gsize i = 0; i < n; i++)
+  {
+    x = x * 1103515245u + 12345u;
+    guchar b = (guchar)((x >> 16) & 0xff);
+    if (b == 0x00 || b == 0x0a)
+      b = 0x41;
+    g_string_append_c(s, (gchar)b);
+  }
+  return s;
+}
+
+/* Runs process_stream() over `wire` and returns the bytes it wrote to `name`.
+ * The buffer is not called `stream`: common_options.h has a global of that
+ * name and the project builds with -Wshadow -Werror. */
+static GString *run_stream(const char *label, GString *wire, const char *name)
+{
+  gchar *dir = g_dir_make_tmp("md1687_XXXXXX", NULL);
+  g_assert_nonnull(dir);
+  gchar *in = g_build_filename(dir, "stdin.bin", NULL);
+  g_assert_true(g_file_set_contents(in, wire->str, wire->len, NULL));
+
+  directory = dir;
+  g_assert_nonnull(freopen(in, "rb", stdin));
+  process_stream(NULL);
+
+  gchar   *out = g_build_filename(dir, name, NULL);
+  gchar   *data = NULL;
+  gsize    len = 0;
+  GString *got = NULL;
+  if (g_file_get_contents(out, &data, &len, NULL))
+    got = g_string_new_len(data, len);
+  else
+    fprintf(stderr, "  [%s] %s was never written\n", label, name);
+
+  g_free(data);
+  g_unlink(out);
+  g_unlink(in);
+  g_rmdir(dir);
+  g_free(out);
+  g_free(in);
+  g_free(dir);
+  directory = NULL;
+  return got;
+}
+
+static void expect_identical(const char *label, GString *sent, GString *got)
+{
+  if (got == NULL)
+  {
+    fprintf(stderr, "  FAIL [%s]: nothing received\n", label);
+    failed++;
+    return;
+  }
+  if (got->len != sent->len)
+  {
+    fprintf(stderr, "  FAIL [%s]: received %" G_GSIZE_FORMAT " bytes, sent %" G_GSIZE_FORMAT "\n",
+        label, got->len, sent->len);
+    failed++;
+    return;
+  }
+  gsize bad = 0, first = 0;
+  for (gsize i = 0; i < sent->len; i++)
+    if (got->str[i] != sent->str[i])
+    {
+      if (!bad)
+        first = i;
+      bad++;
+    }
+  if (bad)
+  {
+    fprintf(stderr,
+        "  FAIL [%s]: same size (%" G_GSIZE_FORMAT ") but %" G_GSIZE_FORMAT
+        " byte(s) differ, first at offset %" G_GSIZE_FORMAT " (sent 0x%02x, got 0x%02x)\n",
+        label, sent->len, bad, first,
+        (guchar)sent->str[first], (guchar)got->str[first]);
+    failed++;
+  }
+  else
+  {
+    fprintf(stdout, "  pass [%s]: %" G_GSIZE_FORMAT " bytes identical\n", label, sent->len);
+  }
+}
+
+/* Compares the last `n` bytes of what was sent with the tail of what arrived. */
+static void expect_suffix(const char *label, GString *sent, GString *got, gsize n)
+{
+  if (got == NULL)
+  {
+    fprintf(stderr, "  FAIL [%s]: nothing received\n", label);
+    failed++;
+    return;
+  }
+  if (got->len < n || sent->len < n)
+  {
+    fprintf(stderr, "  FAIL [%s]: too short (received %" G_GSIZE_FORMAT ", sent %" G_GSIZE_FORMAT ", want %" G_GSIZE_FORMAT ")\n",
+        label, got->len, sent->len, n);
+    failed++;
+    return;
+  }
+  const gchar *a = sent->str + sent->len - n;
+  const gchar *b = got->str + got->len - n;
+  gsize        bad = 0, first = 0;
+  for (gsize i = 0; i < n; i++)
+    if (a[i] != b[i])
+    {
+      if (!bad)
+        first = i;
+      bad++;
+    }
+  if (bad)
+  {
+    fprintf(stderr,
+        "  FAIL [%s]: %" G_GSIZE_FORMAT " of the last %" G_GSIZE_FORMAT
+        " bytes differ, first at tail offset %" G_GSIZE_FORMAT " (sent 0x%02x, got 0x%02x)\n",
+        label, bad, n, first, (guchar)a[first], (guchar)b[first]);
+    failed++;
+  }
+  else
+  {
+    fprintf(stdout, "  pass [%s]: last %" G_GSIZE_FORMAT " bytes identical\n", label, n);
+  }
+}
+
+/* Compares the first `n` bytes of what was sent with the head of what arrived. */
+static void expect_prefix(const char *label, GString *sent, GString *got, gsize n)
+{
+  if (got == NULL)
+  {
+    fprintf(stderr, "  FAIL [%s]: nothing received\n", label);
+    failed++;
+    return;
+  }
+  if (got->len < n || sent->len < n)
+  {
+    fprintf(stderr, "  FAIL [%s]: too short (received %" G_GSIZE_FORMAT ", want %" G_GSIZE_FORMAT ")\n",
+        label, got->len, n);
+    failed++;
+    return;
+  }
+  gsize bad = 0, first = 0;
+  for (gsize i = 0; i < n; i++)
+    if (sent->str[i] != got->str[i])
+    {
+      if (!bad)
+        first = i;
+      bad++;
+    }
+  if (bad)
+  {
+    fprintf(stderr,
+        "  FAIL [%s]: %" G_GSIZE_FORMAT " of the first %" G_GSIZE_FORMAT
+        " bytes differ, first at offset %" G_GSIZE_FORMAT " (sent 0x%02x, got 0x%02x)\n",
+        label, bad, n, first, (guchar)sent->str[first], (guchar)got->str[first]);
+    failed++;
+  }
+  else
+  {
+    fprintf(stdout, "  pass [%s]: first %" G_GSIZE_FORMAT " bytes identical\n", label, n);
+  }
+}
+
+/* ── the two mydumper-stream carry-over sites ─────────────────────────────── */
+
+/*
+ * Short-tail site: the last three bytes of the first buffer are LF, NUL, X.
+ * g_strndup()/strlen() shrink the tail to "\n", which is a substring of
+ * "\n-- ", so the carry-over fires; g_strlcpy() then moves 1 byte of the 3.
+ */
+static void test_mydumper_short_tail(void)
+{
+  const char *name = "md1687.probe.bin";
+  const gsize size = STREAM_BUFFER_SIZE + 200000; /* spans the boundary */
+  GString    *hdr = stream_header(name, size);
+  GString    *body = filler(size, 1687);
+
+  gsize i0 = FIRST_BUFFER_LEN - 3 - hdr->len; /* payload index of the LF */
+  body->str[i0] = '\n';
+  body->str[i0 + 1] = '\0';
+  body->str[i0 + 2] = 'X';
+
+  GString *wire = g_string_new_len(hdr->str, hdr->len);
+  g_string_append_len(wire, body->str, body->len);
+  g_assert_cmpint(memcmp(wire->str + FIRST_BUFFER_LEN - 3, "\n\0X", 3), ==, 0);
+
+  expect_identical("mydumper: short tail across the buffer boundary",
+      body, run_stream("short tail", wire, name));
+
+  g_string_free(wire, TRUE);
+  g_string_free(body, TRUE);
+  g_string_free(hdr, TRUE);
+}
+
+/*
+ * Long-tail site: a chance "\n-- " inside the payload lands near the end of
+ * the buffer, so the whole tail from it is carried over. The tail is payload
+ * bytes, and g_strlcpy() stops at the first NUL in it.
+ */
+static void test_mydumper_chance_header(void)
+{
+  const char *name = "md1687.probea.bin";
+  const gsize size = STREAM_BUFFER_SIZE + 200000; /* spans the boundary */
+  GString    *hdr = stream_header(name, size);
+  GString    *body = filler(size, 16871);
+
+  gsize tag = FIRST_BUFFER_LEN - 99 - hdr->len; /* payload index of "\n-- " */
+  memcpy(body->str + tag, "\n-- ", 4);
+  body->str[tag + 10] = '\0';                          /* first NUL inside the tail */
+  body->str[FIRST_BUFFER_LEN + 101 - hdr->len] = '\n'; /* ends the false line */
+
+  GString *wire = g_string_new_len(hdr->str, hdr->len);
+  g_string_append_len(wire, body->str, body->len);
+
+  expect_identical("mydumper: chance \"\\n-- \" near the buffer boundary",
+      body, run_stream("chance header", wire, name));
+
+  g_string_free(wire, TRUE);
+  g_string_free(body, TRUE);
+  g_string_free(hdr, TRUE);
+}
+
+/* ── the mysqldump-path short-tail site ───────────────────────────────────── */
+
+/*
+ * myloader --mysqldump. The buffer ends with a partial line shorter than 20
+ * bytes while a file is open, so process_stream() carries that tail back to
+ * the front to get enough context for its CREATE TABLE / INSERT INTO prefix
+ * match. If the tail holds a NUL, the old g_strlcpy() moved only the bytes
+ * before it.
+ *
+ * Real mysqldump output cannot reach this: it escapes 0x00 as the two
+ * characters \0 and never emits a literal NUL. The site is reachable here
+ * because process_stream() parses whatever arrives on stdin.
+ *
+ * The assertion is on the tail of the payload rather than the whole file:
+ * in mysqldump mode the file also receives the accumulated SET statements,
+ * and opening it flushes a zero-length range, so only the payload part is
+ * predictable.
+ */
+static void test_mysqldump_short_tail(void)
+{
+  GString *prologue = g_string_new(
+      "/*!40101 SET NAMES utf8mb4 */;\n" /* -> set_buffer */
+      "--\n"                             /* the "--" line   */
+      "\n");                             /* blank: opens a file */
+  const gsize size = STREAM_BUFFER_SIZE + 200000; /* spans the boundary */
+  GString    *body = filler(size, 168701);
+
+  /* every 40th byte a newline, so the payload is lines rather than one blob */
+  for (gsize i = 39; i < size; i += 40)
+    body->str[i] = '\n';
+
+  /* a 9-byte tail: the LF sits 9 bytes before the end of buffer 1 */
+  gsize eol = FIRST_BUFFER_LEN - 9 - prologue->len; /* payload index of that LF */
+  body->str[eol] = '\n';
+  body->str[eol + 3] = '\0'; /* NUL inside the 8-byte tail */
+  for (gsize i = eol + 1; i < eol + 8; i++)
+    if (i != eol + 3 && body->str[i] == '\n')
+      body->str[i] = 'Z';   /* the tail must be one partial line */
+  body->str[eol + 8] = 'Q'; /* last byte of the buffer, and of the tail */
+
+  GString *wire = g_string_new_len(prologue->str, prologue->len);
+  g_string_append_len(wire, body->str, body->len);
+  g_assert_cmpint(wire->str[FIRST_BUFFER_LEN - 9], ==, '\n');
+  g_assert_cmpint(wire->str[FIRST_BUFFER_LEN - 6], ==, '\0');
+
+  mysqldump = TRUE;
+  GString *got = run_stream("mysqldump short tail", wire, "mydumper_tmp.table_0.sql");
+  mysqldump = FALSE;
+
+  /* the whole payload: in mysqldump mode the file also starts with the SET
+   * statements, so only the payload tail of it is predictable. */
+  expect_suffix("mysqldump: short tail across the buffer boundary", body, got, size);
+
+  g_string_free(wire, TRUE);
+  g_string_free(body, TRUE);
+  g_string_free(prologue, TRUE);
+}
+
+/*
+ * myloader --mysqldump, header phase. Before the first file is opened every
+ * non-comment line is accumulated into set_buffer, and a line that straddles
+ * the buffer boundary is carried over the same way. A NUL in that partial line
+ * truncated the old g_strlcpy(), so bytes vanished from the SET block that is
+ * later written at the head of the first file.
+ *
+ * Real mysqldump output cannot reach this either: it puts a blank line after
+ * the first "--" block about 1.5 KB in, so the header phase is over long
+ * before the 1 MB boundary. Here the header is made larger than one buffer.
+ */
+static void test_mysqldump_header_line(void)
+{
+  const gsize hdr_size = STREAM_BUFFER_SIZE + 100000; /* larger than one buffer */
+  GString    *head = filler(hdr_size, 168702);
+
+  for (gsize i = 39; i < hdr_size; i += 40) /* lines, never two LF in a row */
+    head->str[i] = '\n';
+  for (gsize i = 0; i < hdr_size; i++) /* no line may start with "--" */
+    if (head->str[i] == '-')
+      head->str[i] = 'D';
+
+  gsize eol = FIRST_BUFFER_LEN - 9; /* last complete line ends here */
+  head->str[eol] = '\n';
+  head->str[eol + 3] = '\0'; /* NUL inside the 8-byte tail */
+  for (gsize i = eol + 1; i < FIRST_BUFFER_LEN; i++)
+    if (i != eol + 3 && head->str[i] == '\n')
+      head->str[i] = 'Z';
+  head->str[hdr_size - 1] = '\n'; /* the block ends on a line */
+
+  GString *wire = g_string_new_len(head->str, head->len);
+  g_string_append(wire, "--\n"); /* the "--" line   */
+  g_string_append(wire, "\n");   /* blank: opens a file */
+  GString *body = filler(4000, 168703);
+  g_string_append_len(wire, body->str, body->len);
+
+  mysqldump = TRUE;
+  GString *got = run_stream("mysqldump header", wire, "mydumper_tmp.table_0.sql");
+  mysqldump = FALSE;
+
+  /* set_buffer is written first, so the file must start with the whole block */
+  expect_prefix("mysqldump: header line across the buffer boundary", head, got, hdr_size);
+
+  g_string_free(wire, TRUE);
+  g_string_free(body, TRUE);
+  g_string_free(head, TRUE);
+}
+
+int main(void)
+{
+  fprintf(stdout, "=== test_stream_carryover ===\n");
+  test_mydumper_short_tail();
+  test_mydumper_chance_header();
+  test_mysqldump_short_tail();
+  test_mysqldump_header_line();
+
+  fprintf(stdout, "\n");
+  if (failed)
+  {
+    fprintf(stderr, "RESULT: %d test(s) FAILED\n", failed);
+    return 1;
+  }
+  fprintf(stdout, "RESULT: ALL TESTS PASSED\n");
+  return 0;
+}


### PR DESCRIPTION
Thanks for confirming the root cause on the issue, and for the invitation to open this.

`Refs #1687` rather than `Fixes` — see "Does this close the issue?" at the bottom.

## The defect

`src/myloader/myloader_stream.c`, four sites — lines **240, 291, 449 and 469** on `master` at `66a0cb37`, which is what this branch is based on. (On the branch they are one higher: the fix adds `#include <string.h>`.) When a buffer boundary falls inside what could be a file header, the stream thread moves the tail of the buffer back to the front and reads the rest on the next `fread()`:

```c
diff = buffer_len - initial_pos;
g_strlcpy(buffer, &(buffer[initial_pos]), diff + 1);
```

`g_strlcpy()` is a string function: it stops at the first `0x00`. The carry-over length is computed arithmetically (`diff`), so on any byte range containing a NUL the two silently disagree — only the bytes before the NUL are moved, the rest keep whatever the previous buffer left at those offsets, and the next read still starts at `diff`.

**The byte count is preserved.** `total_size` never drifts, the header size check still matches, and nothing at all is logged. The file lands on disk with the right size and the wrong content — which is why `zstd` reports `data corruption detected`
rather than a truncation error.

Your explanation lines up with what I measured: `mysqldump` escapes `0x00` as the two characters `\0` and never emits a literal NUL, so without compression there is simply no NUL for `g_strlcpy()` to stop on. It only becomes reachable once the
payload is compressed.

## The fix

`memmove()` at all four sites. It moves exactly the requested number of bytes, does not stop at a NUL, and is defined for overlapping ranges. Only the first hunk needed its length argument rewritten: `diff` already holds `line_end - line_from`, and the old `+ 1` was `g_strlcpy()`'s buffer size, not a byte count.

## Tests

**`test/specific_41`** — end to end, covers the two sites on the mydumper stream path. The trigger is a chance byte pattern at a buffer boundary, far too rare to hit at test scale, so the case builds it: it appends one synthetic file to the stream mydumper just produced and pads it until `LF`, `NUL`, `X` land on the last three bytes of the first buffer.

`--stream=UNPACK` keeps the received files and skips the restore, so the case asserts byte fidelity without touching server state. myloader is driven from the check script rather than by the harness because the harness fails any case that leaves files behind.

**`test/unit/test_stream_carryover.c`** — links the real `process_stream()` and drives it over hand-built streams, so it reaches all four sites, including the two on the `--mysqldump` path that cannot be reached end to end (`mysqldump` never emits
a literal NUL, and the header-phase site additionally needs the SET block to exceed one buffer, while `mysqldump` closes it about 1.5 KB in). No server, no database connection, registered with `add_test()`, so it runs in the existing `ctest` step.

Since you mentioned changing `STREAM_BUFFER_SIZE` to reproduce this — the unit test takes the constant from `src/common.h` rather than copying it, so it follows you. I ran it at 2048, 4096 and the stock 1000000: it fails on `master` and passes with the patch at each. Below roughly 2 KB the two `--mysqldump` cases stop being meaningful, because that path truncates the file by itself there — identically with and without this fix — so do not read a failure from them at a very small buffer as this bug.

## The offset, in case it is still useful

The first `fread()` runs with `diff == 0` and asks for `stream_buffer_size - 1` bytes, so buffer 1 holds stream offsets `[0, N-2]` and its last three bytes are:

```
buffer size N  ->  0x0a at N-4,  0x00 at N-3,  any byte at N-2
N = 1000000    ->  999996 / 999997 / 999998
N = 1000       ->     996 /    997 /    998
```

That is the short-tail site. Your skippable-frame file drives the *other* one: a literal `\n-- ` near a boundary makes the whole tail from it carry over, and that tail is compressed content, so it has NULs in it. Shrinking the buffer moves a boundary onto your embedded marker, which is exactly what you reproduced.

## Measured

| build | case | bytes differing | `Different file size` msgs |
|---|---|---|---|
| master  | short tail (`:469`)       | **1**  | 0 |
| patched | short tail                | 0      | 0 |
| master  | chance `\n-- ` (`:449`)   | **88** | 1 |
| patched | chance `\n-- `            | **0**  | 1 |

The last row is the point: the message survives the fix and the data is intact. The two problems are independent.

Also run: the full `specific_*` suite (38 cases, clean, compared against a pristine `master` baseline on the same box), a 34 MB `--compress --chunk-filesize=1 --stream=NO_DELETE` round trip with all 27 files md5-identical and row counts equal, a `-Werror` build with zero warnings, and `clang-format` 22 reporting no change for `src/myloader/myloader_stream.c` — I checked the file this touches rather than the whole tree.

All of that is one platform though — Debian bookworm aarch64 with the MySQL 8.4 client. The unit test compiles a real source file, so the portability check that matters is the CI matrix rather than my box; it is green on this branch, all 37 executors, el7 through resolute. If something does turn up there later I will fix it, or drop the unit test to a follow-up and leave the fix and `test/specific_41` here.

## The `trace()` commit

Last commit, separate on purpose so you can drop it independently. `trace()` rather than `g_debug()`, as you asked.

## Does this close the issue?

I left it as `Refs #1687` rather than `Fixes`. This patch fixes the silent corruption, but the symptom actually reported there is the `Different file size … But continuing` message, which is a false positive and still occurs — the third commit only lowers its level. There are also other observations still open in that thread. Your call: if you want it closed, `Fixes #1687` in the squash commit does it.

## Noticed while working on this, deliberately left out

None of these are touched here; the diff is meant to map 1:1 onto the root cause.

- `myloader` emits a GLib-CRITICAL when no defaults file is given —   `src/myloader/myloader.c:572` calls `load_per_table_info_from_key_file(key_file, …)`   outside the `if (key_file != NULL)` guard three lines above. Invisible normally   because the harness always passes `--defaults-extra-file`; under   `G_DEBUG=fatal-criticals` it is a SIGTRAP.
- `myloader --mysqldump --stream` is broken before any of this matters. `flush()` gets   called with `to < from`, so `write_file(file, ptr, -1)`; the check is   `write_file(...) != to - from + 1` and `write(2)` returns `-1`, so `-1 != -1` is   false and nothing is reported, while `*total_size += (to - from) + 1` decrements a  `guint`. Same on `master` and on this branch.
- `total_size` and `file_size_from_stream` are `guint` but printed with `%d` — that   is where `Written: -430023011` in the original report comes from.
- No `pos < buffer_len` guard on `while (buffer[pos] == '\n') pos++;`, and   `buffer[line_end]` is read when `line_end == buffer_len`. Benign on a full read because that byte is the never-written sentinel, stale on a short read.
- Same file, same convention as the `trace()` change: a leftover `g_message("Copying")` at `:239` and a `g_debug("Not a mydumper file")` at `:427`. Happy to fold them in if you want them.