### PR TITLE
myloader: remove unlocked walk of conf.table_list that raced with refresh_table_list

### DIFF
--- a/src/myloader/myloader.c
+++ b/src/myloader/myloader.c
@@ -730,16 +730,6 @@ int main(int argc, char *argv[])
     wait_stream_to_finish();
   }
 
-  GList *tl = conf.table_list;
-  while (tl != NULL)
-  {
-    if (((struct db_table *)(tl->data))->max_connections_per_job == 1)
-    {
-      ((struct db_table *)(tl->data))->max_connections_per_job = 0;
-    }
-    tl = tl->next;
-  }
-
   wait_schema_worker_to_finish(&conf);
   wait_worker_loader_main();
   enqueue_indexes_if_possible(&conf);
@@ -769,7 +759,7 @@ int main(int argc, char *argv[])
                                                                                          : "skip",
         NULL);
   }
-  tl = conf.table_list;
+  GList           *tl = conf.table_list;
   struct db_table *dbt;
   while (tl != NULL)
   {

--- a/src/myloader/myloader_table.c
+++ b/src/myloader/myloader_table.c
@@ -125,7 +125,6 @@ gboolean append_new_db_table(struct db_table **p_dbt, struct database *_database
 
       dbt->current_threads = 0;
       dbt->max_threads = max_threads_per_table > num_threads ? num_threads : max_threads_per_table;
-      dbt->max_connections_per_job = 0;
       dbt->retry_count = retry_count;
       dbt->mutex = g_mutex_new();
       dbt->schema_cond = g_cond_new();

--- a/src/myloader/myloader_table.h
+++ b/src/myloader/myloader_table.h
@@ -40,7 +40,6 @@ struct db_table
   gboolean                    restore_job_list_sorted;  // Perf: lazy sorting flag
   guint                       current_threads;
   guint                       max_threads;
-  guint                       max_connections_per_job;
   guint                       retry_count;
   GMutex                     *mutex;
   GCond                      *schema_cond; /* Condition variable for schema-wait synchronization */


### PR DESCRIPTION
## Summary

Remove an unlocked walk of `conf.table_list` in myloader's `main()` that could run while a schema worker was freeing the list, crashing `--stream` imports with SIGSEGV.

## Bug

`main()` walked `conf.table_list` without taking `conf.table_list_mutex`, right after `wait_stream_to_finish()` and before `wait_schema_worker_to_finish()`.

Every schema worker calls `refresh_table_list()` on exit. That rebuilds the list and `g_list_free()`s the old one under the mutex, so `main()` could be walking freed nodes. Every other reader of the list (schema, index and loader workers) takes the mutex; this walk was the only exception.

Observed as a SIGSEGV in a few percent of `--stream` imports, most often with `--max-threads-for-schema-creation 1`: schema creation finishes in seconds, data streams for minutes, and the idle schema thread exits — and refreshes the list — while `main()` is walking it.

## Fix

The walk only reset `max_connections_per_job` from `1` to `0`, and that field is never assigned anything but `0` and is read nowhere else, so it was dead code. Drop the walk and the field rather than lock around a loop that can never do anything.

The later walk in `main()` (checksums) is unchanged: by then the stream/directory thread and the schema workers are joined, and the restore, index and post workers never refresh the list.

## Test

ThreadSanitizer build, 30 stream imports each, in the shape described above (`--max-threads-for-schema-creation 1`, ~1 s pause before EOF):

- Before: 3 runs report `main` (`myloader.c:736`) racing `worker_schema_thread` → `refresh_table_list`.
- After: none; imports complete with row counts matching the source.

`ctest` passes; build is clean with `-Werror`, on master at `26f2b295`.
