### PR TITLE
myloader: remove fifo_hash entry on myl_close to stop stale FILE* lookups

### DIFF
--- a/src/myloader/myloader_process.c
+++ b/src/myloader/myloader_process.c
@@ -153,29 +153,14 @@ FILE *myl_open(char *filename, const char *type)
         m_remove(directory,tmpbasename);
         g_free(tmpbasename);
     */
+    struct fifo *f = g_new0(struct fifo, 1);
+    f->pid = child_proc;
+    f->filename = g_strdup(filename);
+    f->stdout_filename = fifoname;
+    f->uses_decompressor = TRUE;
     g_mutex_lock(fifo_table_mutex);
-    struct fifo *f = g_hash_table_lookup(fifo_hash, file);
-    if (f != NULL)
-    {
-      g_mutex_lock(f->mutex);
-      g_mutex_unlock(fifo_table_mutex);
-      f->pid = child_proc;
-      f->filename = g_strdup(filename);
-      f->stdout_filename = fifoname;
-      f->uses_decompressor = TRUE;
-    }
-    else
-    {
-      f = g_new0(struct fifo, 1);
-      f->mutex = g_mutex_new();
-      g_mutex_lock(f->mutex);
-      f->pid = child_proc;
-      f->filename = g_strdup(filename);
-      f->stdout_filename = fifoname;
-      f->uses_decompressor = TRUE;
-      g_hash_table_insert(fifo_hash, file, f);
-      g_mutex_unlock(fifo_table_mutex);
-    }
+    g_hash_table_insert(fifo_hash, file, f);
+    g_mutex_unlock(fifo_table_mutex);
   }
   else
   {
@@ -198,8 +183,13 @@ FILE *myl_open(char *filename, const char *type)
 void myl_close(const char *filename, FILE *file, gboolean rm)
 {
   trace("myl_close %s", filename);
+  // Remove the entry before closing: fclose() frees the FILE, and a later
+  // fopen() can hand out the same address, so a stale entry would be found
+  // by the next myl_close() on an unrelated (possibly uncompressed) file.
   g_mutex_lock(fifo_table_mutex);
   struct fifo *f = g_hash_table_lookup(fifo_hash, file);
+  if (f != NULL)
+    g_hash_table_remove(fifo_hash, file);
   g_mutex_unlock(fifo_table_mutex);
   fclose(file);
 
@@ -207,9 +197,6 @@ void myl_close(const char *filename, FILE *file, gboolean rm)
   {
     int status = 0;
     waitpid(f->pid, &status, 0);
-    g_mutex_lock(fifo_table_mutex);
-    g_mutex_unlock(f->mutex);
-    g_mutex_unlock(fifo_table_mutex);
 
     // Issue #2075: FIFO is already unlinked in myl_open() after both ends connect.
     // No need to remove here - the FIFO name no longer exists on filesystem.
@@ -219,6 +206,9 @@ void myl_close(const char *filename, FILE *file, gboolean rm)
     {
       release_decompressor_slot();
     }
+    g_free(f->filename);
+    g_free(f->stdout_filename);
+    g_free(f);
   }
   (void)rm;
   (void)filename;

--- a/src/myloader/myloader_process.h
+++ b/src/myloader/myloader_process.h
@@ -30,7 +30,6 @@ struct fifo
   int      pid;
   gchar   *filename;
   gchar   *stdout_filename;
-  GMutex  *mutex;
   gboolean uses_decompressor;  // Track if this file uses a decompression slot
 };
 


### PR DESCRIPTION
## Summary

Remove a file's `fifo_hash` entry in `myl_close()` so a later file that reuses the same `FILE*` address does not pick up the stale entry and abort myloader.

## Bug

`fifo_hash` maps `FILE*` → `struct fifo` for files read through a decompressor. `myl_close()` looked the entry up, `waitpid`ed the child and unlocked the entry's mutex, but never removed the entry.

`fclose()` frees the `FILE`, and a later `fopen()` can return the same address for a file that has no decompressor. The next `myl_close()` on that file then finds the stale entry and unlocks a mutex nobody holds, and glib aborts:

```
GLib: Attempt to unlock mutex that was not locked
```

Any restore mixing compressed and uncompressed files hits it — for instance a compressed dump where some files were decompressed by hand, or a stream carrying both.

## Fix

- `myl_close()`: remove the entry under `fifo_table_mutex` before `fclose()`, then free it after `waitpid()`.
- `myl_open()`: always create a fresh entry. The previous "entry already exists for this `FILE*`" branch only handled address reuse and cannot trigger once entries are removed on close.
- Drop `struct fifo.mutex`: it existed only to serialise that reuse, and was locked in one thread and unlocked in another, which GMutex does not allow.

## Test

Dump `--compress`, decompress every third file, restore from the directory with `-t 8`:

- Before: 10/10 runs abort with the message above.
- After: 10/10 complete; row and table counts match the source.

`ctest` passes; build is clean with `-Wall -Wextra -Werror`, on master at `26f2b295`.
