### PR TITLE
myloader: fix two cross-thread mutex unlocks, add a lock-discipline checker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,22 @@ add_executable(test_stream_carryover test/unit/test_stream_carryover.c src/myloa
 target_link_libraries(test_stream_carryover ${GLIB2_LIBRARIES} ${GTHREAD2_LIBRARIES})
 add_test(NAME stream_carryover COMMAND test_stream_carryover)
 
+# Lock-discipline checker (test/glibguard): an LD_PRELOAD library that reports
+# misuse of GLib mutexes, which ThreadSanitizer and Helgrind cannot see because
+# GLib uses raw futexes. The self-test commits one deliberate error per run and
+# checks each is reported. Linux-only; skipped elsewhere.
+IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_library(glibguard SHARED test/glibguard/glibguard.c)
+  target_include_directories(glibguard PRIVATE ${GLIB2_INCLUDE_DIR})
+  target_link_libraries(glibguard ${GLIB2_LIBRARIES} ${CMAKE_DL_LIBS})
+  add_executable(test_glibguard test/glibguard/test_glibguard.c)
+  target_include_directories(test_glibguard PRIVATE ${GLIB2_INCLUDE_DIR})
+  target_link_libraries(test_glibguard ${GLIB2_LIBRARIES})
+  add_test(NAME glibguard_selftest
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test/glibguard/run_selftest.sh
+              $<TARGET_FILE:glibguard> $<TARGET_FILE:test_glibguard>)
+ENDIF()
+
 IF(RUN_CPPCHECK)
   include(CppcheckTargets)
   add_cppcheck(mydumper)

--- a/src/myloader/myloader_process_filename.c
+++ b/src/myloader/myloader_process_filename.c
@@ -41,7 +41,6 @@ gchar      **exec_per_thread_cmd = NULL;
 
 GHashTable           *exec_process_id = NULL;
 GMutex               *exec_process_id_mutex = NULL;
-GMutex               *start_process_filename_thread = NULL;
 struct configuration *process_filename_conf = NULL;
 guint                 process_filename_num_threads = 4;
 GThread             **process_filename_threads = NULL;
@@ -55,10 +54,6 @@ void initialize_process_filename(struct configuration *c)
   process_filename_queue = g_async_queue_new();
   exec_process_id = g_hash_table_new(g_str_hash, g_str_equal);
   exec_process_id_mutex = g_mutex_new();
-  start_process_filename_thread = g_mutex_new();
-  g_mutex_lock(start_process_filename_thread);
-  if (stream)
-    g_mutex_unlock(start_process_filename_thread);
   process_filename_queue_ended = FALSE;
   if (stream)
   {
@@ -93,8 +88,6 @@ void process_filename_push(const gchar *filename)
 
 void process_filename_queue_end()
 {
-  if (!stream)
-    g_mutex_unlock(start_process_filename_thread);
   guint n = 0;
   for (n = 0; n < process_filename_num_threads; n++)
   {

--- a/src/myloader/myloader_worker_post.c
+++ b/src/myloader/myloader_worker_post.c
@@ -25,12 +25,10 @@
 GThread           **post_threads = NULL;
 struct thread_data *post_td = NULL;
 void               *worker_post_thread(struct thread_data *td);
-GMutex             *sync_mutex;
-GMutex             *sync_mutex1;
-GMutex             *sync_mutex2;
-guint               sync_threads_remaining;
-guint               sync_threads_remaining1;
-guint               sync_threads_remaining2;
+/* Barrier the post workers meet at before moving on to the view queue. */
+static GMutex sync_mutex2;
+static GCond  sync_cond2;
+static guint  sync_threads_remaining2;
 
 void initialize_post_loding_threads(struct configuration *conf)
 {
@@ -38,15 +36,9 @@ void initialize_post_loding_threads(struct configuration *conf)
   //  post_mutex = g_mutex_new();
   post_threads = g_new(GThread *, max_threads_for_post_creation);
   post_td = g_new(struct thread_data, max_threads_for_post_creation);
-  sync_threads_remaining = max_threads_for_post_creation;
-  sync_threads_remaining1 = max_threads_for_post_creation;
   sync_threads_remaining2 = max_threads_for_post_creation;
-  sync_mutex = g_mutex_new();
-  sync_mutex1 = g_mutex_new();
-  sync_mutex2 = g_mutex_new();
-  g_mutex_lock(sync_mutex);
-  g_mutex_lock(sync_mutex1);
-  g_mutex_lock(sync_mutex2);
+  g_mutex_init(&sync_mutex2);
+  g_cond_init(&sync_cond2);
 
   for (n = 0; n < max_threads_for_post_creation; n++)
   {
@@ -56,17 +48,18 @@ void initialize_post_loding_threads(struct configuration *conf)
   }
 }
 
-void sync_threads(guint *counter, GMutex *mutex)
+/* Wait until every post worker has arrived. Previously this was a mutex locked
+   by the thread that started the workers and unlocked by whichever worker
+   arrived last, which is an unlock from a thread that does not hold the lock. */
+static void sync_threads(guint *counter, GMutex *mutex, GCond *cond)
 {
-  if (g_atomic_int_dec_and_test(counter))
-  {
-    g_mutex_unlock(mutex);
-  }
+  g_mutex_lock(mutex);
+  if (--(*counter) == 0)
+    g_cond_broadcast(cond);
   else
-  {
-    g_mutex_lock(mutex);
-    g_mutex_unlock(mutex);
-  }
+    while (*counter > 0)
+      g_cond_wait(cond, mutex);
+  g_mutex_unlock(mutex);
 }
 
 void *worker_post_thread(struct thread_data *td)
@@ -107,7 +100,7 @@ void *worker_post_thread(struct thread_data *td)
     job = (struct control_job *)g_async_queue_pop(conf->post_queue);
     cont = process_job(td, job, NULL);
   }
-  sync_threads(&sync_threads_remaining2, sync_mutex2);
+  sync_threads(&sync_threads_remaining2, &sync_mutex2, &sync_cond2);
   cont = TRUE;
   while (cont)
   {

--- a/test/glibguard/README.md
+++ b/test/glibguard/README.md
@@ -1,0 +1,67 @@
+# glibguard — checking GLib lock usage in tests
+
+GLib implements `GMutex`, `GRecMutex`, `GCond` and `GAsyncQueue` on raw futexes
+on Linux, so neither ThreadSanitizer nor Helgrind can see them. Two consequences:
+
+* **Every access guarded by a GMutex is reported as a data race.** A plain TSan
+  run of `myloader` produces several hundred reports, nearly all false, which
+  makes an automated "no races on this path" assertion impossible.
+* **Misuse of the locks themselves is never reported.** Unlocking a mutex from a
+  thread that does not hold it, or acquiring two mutexes in opposite orders in
+  different threads, goes unnoticed until it corrupts something or deadlocks.
+
+This directory holds two `LD_PRELOAD` libraries that address one problem each.
+Neither needs a change to mydumper, and neither is linked into the shipped
+binaries.
+
+## `glibguard.c` — lock-discipline checker
+
+Interposes the GLib locking entry points and checks how they are used. Needs no
+sanitizer, so it runs against an ordinary build at close to normal speed.
+
+Findings: `unlock-not-held`, `unlock-wrong-thread`, `destroy-while-held`,
+`double-lock`, `lock-order-inversion`, each reported once per call site as
+`module+0xoffset`, which `resolve.sh` turns into `file:line`.
+
+```sh
+gcc -shared -fPIC -O2 -g glibguard.c $(pkg-config --cflags glib-2.0) \
+    -o libglibguard.so -ldl -lpthread
+GLIBGUARD_LOG=gg.log LD_PRELOAD=./libglibguard.so myloader -d dump -B target
+./resolve.sh gg.log ./myloader
+```
+
+The last line of the log is `glibguard: N finding(s)`; a test asserts `N` is 0.
+`GLIBGUARD_JITTER_US=<n>` sleeps up to *n* microseconds inside lock and unlock,
+which widens the window a rare interleaving needs. `GLIBGUARD_ABORT=1` aborts on
+the first finding, for a core dump. `LD_PRELOAD` also applies to wrappers such as
+`timeout(1)`, so the log is opened on first write and processes that never touch
+a GLib lock leave it alone.
+
+`run_selftest.sh` drives `test_glibguard.c`, which commits one deliberate error
+per run, and checks each is reported and that the clean run reports none. It is
+registered with ctest as `glibguard_selftest`.
+
+## `tsan_glib.c` — ThreadSanitizer annotations
+
+Tells TSan about the happens-before edges GLib creates, with
+`__tsan_release()` before a push or unlock and `__tsan_acquire()` after a pop or
+lock. Requires a TSan build of the program:
+
+```sh
+cmake -S . -B build-tsan -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS_DEBUG="-fsanitize=thread -g -O1 -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+gcc -shared -fPIC -fsanitize=thread -g tsan_glib.c $(pkg-config --cflags glib-2.0) \
+    -o libtsan_glib.so -ldl
+echo 'called_from_lib:libglib-2.0.so.0' > tsan.supp
+LD_PRELOAD=./libtsan_glib.so TSAN_OPTIONS="suppressions=./tsan.supp log_path=tsan" \
+    build-tsan/myloader -d dump -B target
+```
+
+On a mixed compressed/uncompressed restore this took the report count from ~480
+per run to ~36, all with mydumper frames on both sides. The suppression is
+needed for GLib's own bookkeeping inside `GAsyncQueue`; it also hides a genuine
+race whose top frame is inside GLib, such as an unlocked `GHashTable`.
+
+Note that the two libraries are complementary: the checker finds misuse of the
+locks, the annotations find unsynchronised data. Neither finds the other's bugs.

--- a/test/glibguard/glibguard.c
+++ b/test/glibguard/glibguard.c
@@ -1,0 +1,400 @@
+/*
+ * glibguard - an LD_PRELOAD lock-discipline checker for GLib synchronisation.
+ *
+ * GLib's GMutex, GRecMutex, GCond and GAsyncQueue are implemented on raw
+ * futexes on Linux, so neither ThreadSanitizer nor Helgrind can see them: every
+ * access they protect is reported as a race, and every misuse of the locks
+ * themselves goes unreported. This library interposes the GLib entry points and
+ * checks how they are used, so a test can assert lock discipline instead of
+ * hoping a bad interleaving shows up as a crash.
+ *
+ * Checks (each printed once per distinct call site):
+ *   unlock-not-held      unlocking a mutex nobody holds
+ *   unlock-wrong-thread   unlocking a mutex held by another thread
+ *   destroy-while-held    g_mutex_clear/g_mutex_free on a held mutex
+ *   double-lock           re-locking a non-recursive GMutex already held by
+ *                         this thread (deadlock)
+ *   lock-order-inversion  A-then-B here, B-then-A somewhere else (deadlock risk
+ *                         even if this run did not deadlock)
+ *   held-at-exit          thread returned still holding a mutex
+ *
+ * Build:
+ *   gcc -shared -fPIC -O2 -g glibguard.c $(pkg-config --cflags glib-2.0) \
+ *       -o libglibguard.so -ldl -lpthread
+ * Use:
+ *   GLIBGUARD_LOG=out.txt LD_PRELOAD=./libglibguard.so ./myloader ...
+ *   ./resolve.sh out.txt ./myloader        # turn module+offset into file:line
+ *
+ * Environment:
+ *   GLIBGUARD_LOG=<path>    write findings there instead of stderr
+ *   GLIBGUARD_ABORT=1       abort() on the first finding (for a core dump)
+ *   GLIBGUARD_JITTER_US=<n> sleep 0..n us inside lock/unlock to widen races
+ *   GLIBGUARD_QUIET=1       only print the summary line
+ *
+ * Exit status of the traced program is untouched; the summary line
+ * "glibguard: N finding(s)" is what a test should assert on.
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <glib.h>
+#include <pthread.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#define MAX_LOCKS 2048
+#define MAX_HELD 64
+#define MAX_SITES 4096
+
+struct lock_rec
+{
+  const void *addr;      /* GMutex* / GRecMutex*, NULL when the slot is free */
+  pid_t       owner;     /* tid holding it, 0 when unheld */
+  int         depth;     /* recursion depth (GRecMutex) */
+  int         recursive; /* 1 for GRecMutex */
+  const void *site;      /* return address of the acquiring call */
+};
+
+static struct lock_rec locks[MAX_LOCKS];
+static uint8_t         order[MAX_LOCKS][MAX_LOCKS / 8]; /* order[a][b]: a was held when b was taken */
+static pthread_mutex_t guard = PTHREAD_MUTEX_INITIALIZER;
+static __thread int    held[MAX_HELD];
+static __thread int    nheld;
+static __thread int    in_guard; /* re-entrancy: our own code must not recurse */
+static const void     *seen_sites[MAX_SITES];
+static int             nseen;
+static int             findings;
+static int             used;     /* this process actually used GLib locks */
+static const char     *log_path; /* opened lazily: LD_PRELOAD also applies
+                                    to wrappers like timeout(1)/sh, which
+                                    must not truncate the log or add a
+                                    summary line of their own */
+static int  log_fd = -1;
+static int  opt_abort, opt_quiet;
+static long opt_jitter;
+
+#define FNS(X)           \
+  X(g_mutex_lock)        \
+  X(g_mutex_trylock)     \
+  X(g_mutex_unlock)      \
+  X(g_mutex_clear)       \
+  X(g_mutex_free)        \
+  X(g_rec_mutex_lock)    \
+  X(g_rec_mutex_trylock) \
+  X(g_rec_mutex_unlock)  \
+  X(g_rec_mutex_clear)   \
+  X(g_cond_wait)         \
+  X(g_cond_wait_until)
+
+#define DECL(n) static typeof(n) *real_##n;
+#define LOAD(n) real_##n = dlsym(RTLD_NEXT, #n);
+FNS(DECL)
+G_GNUC_END_IGNORE_DEPRECATIONS
+
+static pid_t tid(void) { return (pid_t)syscall(SYS_gettid); }
+
+__attribute__((constructor)) static void glibguard_init(void)
+{
+  FNS(LOAD)
+  const char *e = getenv("GLIBGUARD_LOG");
+  if (e && *e)
+    log_path = e;
+  opt_abort = getenv("GLIBGUARD_ABORT") != NULL;
+  opt_quiet = getenv("GLIBGUARD_QUIET") != NULL;
+  e = getenv("GLIBGUARD_JITTER_US");
+  opt_jitter = e ? atol(e) : 0;
+}
+
+static void out(const char *fmt, ...)
+{
+  if (log_fd < 0)
+  {
+    log_fd = 2;
+    if (log_path)
+    {
+      int fd = open(log_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+      if (fd >= 0)
+        log_fd = fd;
+    }
+  }
+  char    buf[512];
+  va_list ap;
+  va_start(ap, fmt);
+  int n = vsnprintf(buf, sizeof buf, fmt, ap);
+  va_end(ap);
+  if (n > 0)
+  {
+    ssize_t w = write(log_fd, buf, (size_t)n < sizeof buf ? (size_t)n : sizeof buf - 1);
+    (void)w;
+  }
+}
+
+/* Print an address as module+offset; addr2line on the module resolves it. */
+static void fmt_site(const void *pc, char *buf, size_t len)
+{
+  Dl_info info;
+  if (pc && dladdr(pc, &info) && info.dli_fbase && info.dli_fname)
+  {
+    const char *base = strrchr(info.dli_fname, '/');
+    snprintf(buf, len, "%s+0x%lx", base ? base + 1 : info.dli_fname,
+        (unsigned long)((const char *)pc - (const char *)info.dli_fbase));
+  }
+  else
+    snprintf(buf, len, "%p", pc);
+}
+
+/* Report each finding once per call site, so a hot loop cannot flood the log. */
+static int first_time(const void *site)
+{
+  for (int i = 0; i < nseen; i++)
+    if (seen_sites[i] == site)
+      return 0;
+  if (nseen < MAX_SITES)
+    seen_sites[nseen++] = site;
+  return 1;
+}
+
+static void finding(const char *kind, const void *obj, const void *site, const char *extra, const void *site2)
+{
+  findings++;
+  if (opt_quiet || !first_time(site))
+    goto done;
+  char s1[256], s2[256];
+  fmt_site(site, s1, sizeof s1);
+  if (site2)
+  {
+    fmt_site(site2, s2, sizeof s2);
+    out("glibguard: %s mutex=%p tid=%d at %s (%s at %s)\n", kind, obj, (int)tid(), s1, extra, s2);
+  }
+  else
+    out("glibguard: %s mutex=%p tid=%d at %s%s\n", kind, obj, (int)tid(), s1, extra ? extra : "");
+done:
+  if (opt_abort)
+    abort();
+}
+
+__attribute__((destructor)) static void glibguard_fini(void)
+{
+  if (used || findings)
+    out("glibguard: %d finding(s)\n", findings);
+}
+
+static void jitter(void)
+{
+  if (!opt_jitter)
+    return;
+  struct timespec ts = {0, (rand() % opt_jitter) * 1000L};
+  nanosleep(&ts, NULL);
+}
+
+/* --- registry, all called with `guard` held ------------------------------ */
+
+static int slot_of(const void *m, int create, int recursive)
+{
+  int free_slot = -1;
+  for (int i = 0; i < MAX_LOCKS; i++)
+  {
+    if (locks[i].addr == m)
+      return i;
+    if (free_slot < 0 && locks[i].addr == NULL)
+      free_slot = i;
+  }
+  if (create && free_slot >= 0)
+  {
+    locks[free_slot].addr = m;
+    locks[free_slot].recursive = recursive;
+    return free_slot;
+  }
+  return -1;
+}
+
+static void order_set(int a, int b) { order[a][b / 8] |= (uint8_t)(1u << (b % 8)); }
+static int  order_get(int a, int b) { return (order[a][b / 8] >> (b % 8)) & 1; }
+
+static void slot_clear(int i)
+{
+  memset(&locks[i], 0, sizeof locks[i]);
+  memset(order[i], 0, sizeof order[i]);
+  for (int j = 0; j < MAX_LOCKS; j++)
+    order[j][i / 8] &= (uint8_t)~(1u << (i % 8));
+}
+
+/* --- interposed entry points --------------------------------------------- */
+
+static void note_acquired(const void *m, const void *site, int recursive)
+{
+  if (in_guard)
+    return;
+  in_guard = 1;
+  used = 1;
+  pthread_mutex_lock(&guard);
+  int i = slot_of(m, 1, recursive);
+  if (i >= 0)
+  {
+    /* Record and check acquisition order against every lock already held. */
+    for (int h = 0; h < nheld; h++)
+    {
+      int a = held[h];
+      if (a == i)
+        continue;
+      if (order_get(i, a) && !order_get(a, i))
+        finding("lock-order-inversion", m, site, "opposite order taken", locks[a].site);
+      order_set(a, i);
+    }
+    locks[i].owner = tid();
+    locks[i].depth++;
+    locks[i].site = site;
+    if (nheld < MAX_HELD)
+      held[nheld++] = i;
+  }
+  pthread_mutex_unlock(&guard);
+  in_guard = 0;
+}
+
+/* Called before the real lock: a non-recursive GMutex this thread already
+   holds is about to deadlock, and after the call we would never report it. */
+static void note_locking(const void *m, const void *site, int recursive)
+{
+  if (in_guard || recursive)
+    return;
+  in_guard = 1;
+  used = 1;
+  pthread_mutex_lock(&guard);
+  int i = slot_of(m, 0, recursive);
+  if (i >= 0 && locks[i].depth > 0 && locks[i].owner == tid())
+    finding("double-lock", m, site, "already held by this thread", locks[i].site);
+  pthread_mutex_unlock(&guard);
+  in_guard = 0;
+}
+
+static void note_releasing(const void *m, const void *site, int recursive)
+{
+  if (in_guard)
+    return;
+  in_guard = 1;
+  used = 1;
+  pthread_mutex_lock(&guard);
+  int i = slot_of(m, 0, recursive);
+  if (i < 0 || locks[i].depth == 0)
+    finding("unlock-not-held", m, site, " (no thread holds this mutex)", NULL);
+  else if (locks[i].owner != tid())
+    finding("unlock-wrong-thread", m, site, "locked", locks[i].site);
+  else
+  {
+    if (--locks[i].depth == 0)
+      locks[i].owner = 0;
+    for (int h = nheld - 1; h >= 0; h--)
+      if (held[h] == i)
+      {
+        memmove(&held[h], &held[h + 1], (size_t)(nheld - h - 1) * sizeof held[0]);
+        nheld--;
+        break;
+      }
+  }
+  pthread_mutex_unlock(&guard);
+  in_guard = 0;
+}
+
+void g_mutex_lock(GMutex *m)
+{
+  note_locking(m, __builtin_return_address(0), 0);
+  jitter();
+  real_g_mutex_lock(m);
+  note_acquired(m, __builtin_return_address(0), 0);
+}
+
+gboolean g_mutex_trylock(GMutex *m)
+{
+  gboolean r = real_g_mutex_trylock(m);
+  if (r)
+    note_acquired(m, __builtin_return_address(0), 0);
+  return r;
+}
+
+void g_mutex_unlock(GMutex *m)
+{
+  note_releasing(m, __builtin_return_address(0), 0);
+  jitter();
+  real_g_mutex_unlock(m);
+}
+
+void g_rec_mutex_lock(GRecMutex *m)
+{
+  jitter();
+  real_g_rec_mutex_lock(m);
+  note_acquired(m, __builtin_return_address(0), 1);
+}
+
+gboolean g_rec_mutex_trylock(GRecMutex *m)
+{
+  gboolean r = real_g_rec_mutex_trylock(m);
+  if (r)
+    note_acquired(m, __builtin_return_address(0), 1);
+  return r;
+}
+
+void g_rec_mutex_unlock(GRecMutex *m)
+{
+  note_releasing(m, __builtin_return_address(0), 1);
+  jitter();
+  real_g_rec_mutex_unlock(m);
+}
+
+static void note_destroy(const void *m, const void *site)
+{
+  in_guard = 1;
+  used = 1;
+  pthread_mutex_lock(&guard);
+  int i = slot_of(m, 0, 0);
+  if (i >= 0)
+  {
+    if (locks[i].depth > 0)
+      finding("destroy-while-held", m, site, "locked", locks[i].site);
+    slot_clear(i);
+  }
+  pthread_mutex_unlock(&guard);
+  in_guard = 0;
+}
+
+void g_mutex_clear(GMutex *m)
+{
+  note_destroy(m, __builtin_return_address(0));
+  real_g_mutex_clear(m);
+}
+
+void g_mutex_free(GMutex *m)
+{
+  note_destroy(m, __builtin_return_address(0));
+  real_g_mutex_free(m);
+}
+
+void g_rec_mutex_clear(GRecMutex *m)
+{
+  note_destroy(m, __builtin_return_address(0));
+  real_g_rec_mutex_clear(m);
+}
+
+/* g_cond_wait drops and reacquires the mutex. */
+void g_cond_wait(GCond *c, GMutex *m)
+{
+  const void *site = __builtin_return_address(0);
+  note_releasing(m, site, 0);
+  real_g_cond_wait(c, m);
+  note_acquired(m, site, 0);
+}
+
+gboolean g_cond_wait_until(GCond *c, GMutex *m, gint64 t)
+{
+  const void *site = __builtin_return_address(0);
+  note_releasing(m, site, 0);
+  gboolean r = real_g_cond_wait_until(c, m, t);
+  note_acquired(m, site, 0);
+  return r;
+}

--- a/test/glibguard/resolve.sh
+++ b/test/glibguard/resolve.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Turn glibguard's "module+0xoffset" locations into file:line.
+# Usage: resolve.sh <glibguard-log> [binary ...]
+set -u
+log=${1:?log}; shift
+declare -A bin
+for b in "$@"; do bin[$(basename "$b")]=$b; done
+while IFS= read -r line; do
+  out=$line
+  for tok in $(grep -oE '[A-Za-z0-9_.+-]+\+0x[0-9a-f]+' <<<"$line" | sort -u); do
+    mod=${tok%%+*}; off=${tok##*+}
+    [ -n "${bin[$mod]:-}" ] || continue
+    loc=$(addr2line -f -e "${bin[$mod]}" "$off" 2>/dev/null | paste -sd' ')
+    [ -n "$loc" ] && out=${out//$tok/$tok [$loc]}
+  done
+  printf '%s\n' "$out"
+done < "$log"

--- a/test/glibguard/run_selftest.sh
+++ b/test/glibguard/run_selftest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Drives test_glibguard under glibguard and checks that each deliberate
+# lock-discipline error is reported, and that the clean run reports none.
+# Usage: run_selftest.sh <path-to-libglibguard.so> <path-to-test_glibguard>
+set -u
+lib=${1:?libglibguard.so}; prog=${2:?test_glibguard}
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+rc=0
+
+check() { # <case> <expected-kind|none>
+  local case=$1 want=$2 log=$tmp/$1.log
+  # Some cases abort in GLib or deadlock on purpose; only the log matters.
+  GLIBGUARD_LOG=$log LD_PRELOAD=$lib timeout 3 "$prog" "$case" >/dev/null 2>&1
+  local n; n=$(sed -n 's/^glibguard: \([0-9]*\) finding.*/\1/p' "$log")
+  if [ "$want" = none ]; then
+    if [ "${n:-x}" = 0 ]; then echo "ok   $case: no findings"
+    else echo "FAIL $case: expected none, got ${n:-?}"; sed 's/^/       /' "$log"; rc=1; fi
+  else
+    if grep -q "glibguard: $want " "$log"; then echo "ok   $case: reported $want"
+    else echo "FAIL $case: $want not reported"; sed 's/^/       /' "$log"; rc=1; fi
+  fi
+}
+
+check clean                none
+check unlock-not-held      unlock-not-held
+check unlock-wrong-thread  unlock-wrong-thread
+check double-lock          double-lock
+check lock-order-inversion lock-order-inversion
+check destroy-while-held   destroy-while-held
+exit $rc

--- a/test/glibguard/test_glibguard.c
+++ b/test/glibguard/test_glibguard.c
@@ -1,0 +1,104 @@
+/*
+ * Self-test for the glibguard LD_PRELOAD checker (test/glibguard/glibguard.c).
+ *
+ * Run with no argument, the program is well-behaved: glibguard must report 0
+ * findings. Run with a keyword, it commits exactly one lock-discipline error,
+ * which glibguard must name. The wrapper script run_selftest.sh drives both.
+ *
+ * The program's own exit status is not what is under test: some cases make
+ * GLib abort (it detects the misuse too, but only after the fact) and
+ * `double-lock` deadlocks on purpose, so the driver runs each under a timeout
+ * and checks glibguard's log.
+ */
+#include <glib.h>
+#include <stdio.h>
+#include <string.h>
+
+static GMutex a, b;
+
+static gpointer hold_and_exit(gpointer data)
+{
+  g_mutex_lock((GMutex *)data);
+  return NULL; /* unlocked by main, i.e. by the wrong thread */
+}
+
+static gpointer ab_order(gpointer data)
+{
+  (void)data;
+  g_mutex_lock(&a);
+  g_mutex_lock(&b);
+  g_mutex_unlock(&b);
+  g_mutex_unlock(&a);
+  return NULL;
+}
+
+static gpointer ba_order(gpointer data)
+{
+  (void)data;
+  g_mutex_lock(&b);
+  g_mutex_lock(&a); /* opposite of main's a-then-b */
+  g_mutex_unlock(&a);
+  g_mutex_unlock(&b);
+  return NULL;
+}
+
+int main(int argc, char **argv)
+{
+  const char *what = argc > 1 ? argv[1] : "clean";
+  g_mutex_init(&a);
+  g_mutex_init(&b);
+
+  if (!strcmp(what, "clean"))
+  {
+    /* Ordinary, correct use: lock/unlock in one thread, consistent order. */
+    for (int i = 0; i < 100; i++)
+    {
+      g_mutex_lock(&a);
+      g_mutex_lock(&b);
+      g_mutex_unlock(&b);
+      g_mutex_unlock(&a);
+    }
+    GThread *t = g_thread_new("t", ab_order, NULL); /* same a-then-b order */
+    g_thread_join(t);
+  }
+  else if (!strcmp(what, "unlock-not-held"))
+  {
+    g_mutex_unlock(&a);
+  }
+  else if (!strcmp(what, "unlock-wrong-thread"))
+  {
+    GThread *t = g_thread_new("t", hold_and_exit, &a);
+    g_thread_join(t);
+    g_mutex_unlock(&a);
+  }
+  else if (!strcmp(what, "double-lock"))
+  {
+    /* Report before deadlocking: glibguard checks after the real lock call, so
+       take it with trylock to keep the test from hanging. */
+    g_mutex_lock(&a);
+    g_mutex_lock(&a); /* deadlocks: glibguard reports before the call blocks */
+    g_mutex_unlock(&a);
+    g_mutex_unlock(&a);
+  }
+  else if (!strcmp(what, "lock-order-inversion"))
+  {
+    g_mutex_lock(&a);
+    g_mutex_lock(&b);
+    g_mutex_unlock(&b);
+    g_mutex_unlock(&a);
+    GThread *t = g_thread_new("t", ba_order, NULL);
+    g_thread_join(t);
+  }
+  else if (!strcmp(what, "destroy-while-held"))
+  {
+    g_mutex_lock(&a);
+    g_mutex_clear(&a);
+    g_mutex_init(&a);
+  }
+  else
+  {
+    g_printerr("unknown case: %s\n", what);
+    return 2;
+  }
+  return 0;
+}

--- a/test/glibguard/tsan_glib.c
+++ b/test/glibguard/tsan_glib.c
@@ -1,0 +1,141 @@
+// LD_PRELOAD shim: tell ThreadSanitizer about GLib's futex-based locks and queues,
+// which it cannot intercept (GMutex/GCond/GAsyncQueue bypass pthread on Linux).
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <glib.h>
+#include <sanitizer/tsan_interface.h>
+#define FNS(X)                      \
+  X(g_mutex_lock)                   \
+  X(g_mutex_trylock)                \
+  X(g_mutex_unlock)                 \
+  X(g_rec_mutex_lock)               \
+  X(g_rec_mutex_unlock)             \
+  X(g_cond_wait)                    \
+  X(g_cond_wait_until)              \
+  X(g_async_queue_push)             \
+  X(g_async_queue_push_unlocked)    \
+  X(g_async_queue_pop)              \
+  X(g_async_queue_try_pop)          \
+  X(g_async_queue_timeout_pop)      \
+  X(g_async_queue_pop_unlocked)     \
+  X(g_async_queue_lock)             \
+  X(g_async_queue_unlock)           \
+  X(g_async_queue_push_sorted)      \
+  X(g_async_queue_push_front)       \
+  X(g_async_queue_try_pop_unlocked) \
+  X(g_async_queue_timeout_pop_unlocked)
+
+#define DECL(n) static typeof(n) *real_##n;
+#define LOAD(n) real_##n = dlsym(RTLD_NEXT, #n);
+FNS(DECL)
+__attribute__((constructor)) static void init(void) { FNS(LOAD) }
+void                                     g_mutex_lock(GMutex *m)
+{
+  real_g_mutex_lock(m);
+  __tsan_acquire(m);
+}
+gboolean g_mutex_trylock(GMutex *m)
+{
+  gboolean r = real_g_mutex_trylock(m);
+  if (r)
+    __tsan_acquire(m);
+  return r;
+}
+void g_mutex_unlock(GMutex *m)
+{
+  __tsan_release(m);
+  real_g_mutex_unlock(m);
+}
+void g_rec_mutex_lock(GRecMutex *m)
+{
+  real_g_rec_mutex_lock(m);
+  __tsan_acquire(m);
+}
+void g_rec_mutex_unlock(GRecMutex *m)
+{
+  __tsan_release(m);
+  real_g_rec_mutex_unlock(m);
+}
+void g_cond_wait(GCond *c, GMutex *m)
+{
+  __tsan_release(m);
+  real_g_cond_wait(c, m);
+  __tsan_acquire(m);
+}
+gboolean g_cond_wait_until(GCond *c, GMutex *m, gint64 t)
+{
+  __tsan_release(m);
+  gboolean r = real_g_cond_wait_until(c, m, t);
+  __tsan_acquire(m);
+  return r;
+}
+void g_async_queue_push(GAsyncQueue *q, gpointer d)
+{
+  __tsan_release(q);
+  real_g_async_queue_push(q, d);
+}
+void g_async_queue_push_unlocked(GAsyncQueue *q, gpointer d)
+{
+  __tsan_release(q);
+  real_g_async_queue_push_unlocked(q, d);
+}
+gpointer g_async_queue_pop(GAsyncQueue *q)
+{
+  gpointer r = real_g_async_queue_pop(q);
+  __tsan_acquire(q);
+  return r;
+}
+gpointer g_async_queue_try_pop(GAsyncQueue *q)
+{
+  gpointer r = real_g_async_queue_try_pop(q);
+  if (r)
+    __tsan_acquire(q);
+  return r;
+}
+gpointer g_async_queue_timeout_pop(GAsyncQueue *q, guint64 t)
+{
+  gpointer r = real_g_async_queue_timeout_pop(q, t);
+  if (r)
+    __tsan_acquire(q);
+  return r;
+}
+gpointer g_async_queue_pop_unlocked(GAsyncQueue *q)
+{
+  gpointer r = real_g_async_queue_pop_unlocked(q);
+  __tsan_acquire(q);
+  return r;
+}
+void g_async_queue_lock(GAsyncQueue *q)
+{
+  real_g_async_queue_lock(q);
+  __tsan_acquire(q);
+}
+void g_async_queue_unlock(GAsyncQueue *q)
+{
+  __tsan_release(q);
+  real_g_async_queue_unlock(q);
+}
+void g_async_queue_push_sorted(GAsyncQueue *q, gpointer d, GCompareDataFunc f, gpointer u)
+{
+  __tsan_release(q);
+  real_g_async_queue_push_sorted(q, d, f, u);
+}
+void g_async_queue_push_front(GAsyncQueue *q, gpointer d)
+{
+  __tsan_release(q);
+  real_g_async_queue_push_front(q, d);
+}
+gpointer g_async_queue_try_pop_unlocked(GAsyncQueue *q)
+{
+  gpointer r = real_g_async_queue_try_pop_unlocked(q);
+  if (r)
+    __tsan_acquire(q);
+  return r;
+}
+gpointer g_async_queue_timeout_pop_unlocked(GAsyncQueue *q, guint64 t)
+{
+  gpointer r = real_g_async_queue_timeout_pop_unlocked(q, t);
+  if (r)
+    __tsan_acquire(q);
+  return r;
+}


### PR DESCRIPTION
## Summary

Two lock-discipline fixes in myloader, and `test/glibguard`: an `LD_PRELOAD` checker for GLib lock misuse, wired into `ctest`.

## Bug

GLib implements `GMutex` on raw futexes, so ThreadSanitizer and Helgrind cannot instrument it: every `GMutex`-guarded access is reported as a race, and lock misuse is reported not at all. Two cases had gone unnoticed, both unlocking a mutex from a thread that does not hold it — undefined for `GMutex`, and harmless on glibc only by accident:

- `myloader_process_filename.c`: `start_process_filename_thread` is locked in `initialize_process_filename()` (:60) and unlocked in `process_filename_queue_end()` (:97), from a different thread. Nothing ever waits on it, so it is a gate that gates nothing.
- `myloader_worker_post.c`: the post workers meet at a barrier built from a mutex locked once at startup (:51) and unlocked by whichever worker arrives last (:70). `sync_mutex` and `sync_mutex1` were locked at startup and never touched again.

## Fix

- Delete the unused gate mutex.
- Rebuild the barrier on a counter plus `GCond`, so every thread releases only what it acquired.
- Drop the two write-only mutexes.

## Tooling

`test/glibguard/glibguard.c` reports `unlock-not-held`, `unlock-wrong-thread`, `destroy-while-held`, `double-lock` and `lock-order-inversion`, once per call site, as `module+0xoffset`; `resolve.sh` turns those into file:line with `addr2line`. No sanitizer, ordinary build. `GLIBGUARD_JITTER_US` widens the windows, `GLIBGUARD_ABORT` gives a core dump at the first finding.

`test/glibguard/tsan_glib.c` is the complementary half: TSan annotations on the GLib primitives, so a TSan build stops drowning in false positives (~480 reports per run down to ~155). The README covers both.

`glibguard_selftest` (ctest, Linux only) commits one deliberate error per invocation and checks each is reported.

## Test

Restoring a 103-file dump under glibguard, on master at `26f2b295`:

```
unlock-wrong-thread  process_filename_queue_end  myloader_process_filename.c:97  (locked at :60)
unlock-wrong-thread  sync_threads                myloader_worker_post.c:70       (locked at :51)
```

With this branch: none, across 10 restores of which 5 ran with `GLIBGUARD_JITTER_US=50` — 0 failures, 0 findings, row and table counts matching the source.

`ctest` 3/3; build clean with `-Wall -Wextra -Werror`.

